### PR TITLE
Add scaffold for JUCE-based Windows VST host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(VSTHostScaffold VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(MSVC)
+    add_compile_options(/permissive- /Zc:__cplusplus /EHsc /O2 /DNDEBUG)
+endif()
+
+add_definitions(-DVST3_SDK)
+
+option(ENABLE_VST2 "Enable VST2 hosting" ON)
+
+set(JUCE_SUBMODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/JUCE)
+set(VST3_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/VST3_SDK)
+set(VST2_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/vst2sdk)
+
+if(NOT EXISTS ${JUCE_SUBMODULE_DIR}/CMakeLists.txt)
+    message(FATAL_ERROR "JUCE submodule not found. Please initialise submodules under externals/JUCE.")
+endif()
+
+add_subdirectory(externals/JUCE)
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-All thing is your job!
+# VST Host Scaffold
+
+This repository provides a Windows x64 C++20 scaffold for a modular audio-effect VST host built with JUCE and the Steinberg VST3 SDK. It targets MSVC 2022 with CMake 3.22 or newer and sets up the foundation for plugin scanning, graph-based audio routing, and project persistence.
+
+## Directory layout
+
+```
+externals/
+  JUCE/           # JUCE submodule (add with git submodule add)
+  VST3_SDK/       # Steinberg VST3 SDK extracted here
+  vst2sdk/        # Optional Xaymar VST2 clean-room headers
+resources/        # Sample JSON data and future assets
+src/              # Application sources (audio engine, host wrappers, GUI, persistence)
+```
+
+## Prerequisites
+
+* **Visual Studio 2022** with the Desktop development with C++ workload.
+* **CMake 3.22+** on PATH (bundled with VS 2022).
+* **JUCE** checked out as a submodule under `externals/JUCE`:
+  ```bash
+  git submodule add https://github.com/juce-framework/JUCE.git externals/JUCE
+  git submodule update --init --recursive
+  ```
+* **Steinberg VST3 SDK** extracted to `externals/VST3_SDK`.
+* Optional **VST2 headers** from [Xaymar/vst2sdk](https://github.com/Xaymar/vst2sdk) extracted to `externals/vst2sdk`.
+
+## Building
+
+1. Open a **x64 Native Tools Command Prompt for VS 2022**.
+2. Configure with CMake:
+   ```bash
+   cmake -S . -B build -DJUCE_BUILD_EXAMPLES=OFF
+   ```
+3. Build the host:
+   ```bash
+   cmake --build build --config Release
+   ```
+4. The executable `VSTHostApp.exe` is produced under `build/Release/`.
+
+## Runtime notes
+
+* The host prefers **ASIO** drivers and falls back to **WASAPI Exclusive** via JUCE's device selector.
+* Engine processing runs at a configurable sample rate/block size, with device I/O resampled via `juce::LagrangeInterpolator`.
+* Plugins are scanned from user-managed directories. Results are cached to JSON (see `resources/sample-plugin-cache.json`).
+* Projects serialize the processing graph and plugin metadata (`resources/sample-project.json`).
+
+## Next steps
+
+* Implement full plugin instantiation (VST3/VST2) and state capture.
+* Replace the placeholder resampler with r8brain-free for higher fidelity.
+* Expand the graph UI to support drag-and-drop placement and connection editing.
+* Add background workers for crash-safe plugin scanning and preset loading.

--- a/resources/sample-plugin-cache.json
+++ b/resources/sample-plugin-cache.json
@@ -1,0 +1,17 @@
+{
+  "v": 1,
+  "scannedAt": "2024-01-01T00:00:00Z",
+  "plugins": [
+    {
+      "id": "demo-vst3",
+      "name": "Demo Reverb",
+      "format": "VST3",
+      "path": "C:/VST3/DemoReverb.vst3",
+      "category": "Reverb",
+      "ins": 2,
+      "outs": 2,
+      "latency": 32,
+      "blacklisted": false
+    }
+  ]
+}

--- a/resources/sample-project.json
+++ b/resources/sample-project.json
@@ -1,0 +1,9 @@
+{
+  "name": "Example Project",
+  "version": 1,
+  "nodes": [
+    { "id": "00000000-0000-0000-0000-000000000001", "name": "Audio In", "latency": 0 },
+    { "id": "00000000-0000-0000-0000-000000000002", "name": "VST FX", "latency": 64 },
+    { "id": "00000000-0000-0000-0000-000000000003", "name": "Audio Out", "latency": 0 }
+  ]
+}

--- a/src/AppMain.cpp
+++ b/src/AppMain.cpp
@@ -1,0 +1,31 @@
+#include "MainWindow.h"
+
+class VSTHostApplication : public juce::JUCEApplication
+{
+public:
+    const juce::String getApplicationName() override { return "VST Host Scaffold"; }
+    const juce::String getApplicationVersion() override { return "0.1.0"; }
+    bool moreThanOneInstanceAllowed() override { return true; }
+
+    void initialise(const juce::String&) override
+    {
+        mainWindow = std::make_unique<MainWindow>();
+    }
+
+    void shutdown() override
+    {
+        mainWindow.reset();
+    }
+
+    void systemRequestedQuit() override
+    {
+        quit();
+    }
+
+    void anotherInstanceStarted(const juce::String&) override {}
+
+private:
+    std::unique_ptr<MainWindow> mainWindow;
+};
+
+START_JUCE_APPLICATION(VSTHostApplication)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,53 @@
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(SOURCES
+    ${SRC_DIR}/AppMain.cpp
+    ${SRC_DIR}/audio/DeviceEngine.cpp
+    ${SRC_DIR}/audio/Resampler.cpp
+    ${SRC_DIR}/host/PluginHost.cpp
+    ${SRC_DIR}/host/PluginScanner.cpp
+    ${SRC_DIR}/graph/GraphEngine.cpp
+    ${SRC_DIR}/graph/Nodes/AudioIn.h
+    ${SRC_DIR}/graph/Nodes/AudioOut.h
+    ${SRC_DIR}/graph/Nodes/VstFx.h
+    ${SRC_DIR}/graph/Nodes/Gain.h
+    ${SRC_DIR}/graph/Nodes/Mix.h
+    ${SRC_DIR}/graph/Nodes/Split.h
+    ${SRC_DIR}/graph/Nodes/Merge.h
+    ${SRC_DIR}/gui/MainWindow.cpp
+    ${SRC_DIR}/gui/GraphView.cpp
+    ${SRC_DIR}/gui/Preferences.cpp
+    ${SRC_DIR}/gui/PluginBrowser.cpp
+    ${SRC_DIR}/persist/Config.cpp
+    ${SRC_DIR}/persist/Project.cpp
+    ${SRC_DIR}/persist/Preset.cpp
+)
+
+add_executable(VSTHostApp ${SOURCES})
+
+if(ENABLE_VST2)
+    target_compile_definitions(VSTHostApp PRIVATE ENABLE_VST2)
+    target_include_directories(VSTHostApp PRIVATE ${VST2_SDK_DIR}/include)
+endif()
+
+target_include_directories(VSTHostApp
+    PRIVATE
+        ${SRC_DIR}
+        ${VST3_SDK_DIR}
+)
+
+target_link_libraries(VSTHostApp
+    PRIVATE
+        juce::juce_audio_devices
+        juce::juce_audio_basics
+        juce::juce_audio_processors
+        juce::juce_audio_utils
+        juce::juce_gui_extra
+        juce::juce_dsp
+)
+
+juce_generate_juce_header(VSTHostApp)
+
+if(MSVC)
+    target_compile_options(VSTHostApp PRIVATE /permissive- /Zc:__cplusplus /EHsc /O2 /DNDEBUG)
+endif()

--- a/src/audio/DeviceEngine.cpp
+++ b/src/audio/DeviceEngine.cpp
@@ -1,0 +1,104 @@
+#include "audio/DeviceEngine.h"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace host::audio
+{
+    DeviceEngine::DeviceEngine(std::shared_ptr<host::graph::GraphEngine> graphEngine)
+        : graph(std::move(graphEngine))
+    {
+        engineBuffer.setSize(2, config.blockSize);
+    }
+
+    void DeviceEngine::setConfig(const EngineConfig& cfg)
+    {
+        config = cfg;
+        if (graph)
+            graph->setEngineFormat(config.sampleRate, config.blockSize);
+    }
+
+    void DeviceEngine::audioDeviceIOCallback(const float* const* inputChannelData,
+                                             int numInputChannels,
+                                             float* const* outputChannelData,
+                                             int numOutputChannels,
+                                             int numSamples)
+    {
+        ensureBuffers(std::max(1, std::max(numInputChannels, numOutputChannels)), config.blockSize);
+
+        const auto deviceToEngineRatio = deviceFormat.sampleRate > 0.0
+            ? config.sampleRate / deviceFormat.sampleRate
+            : 1.0;
+        const auto engineToDeviceRatio = deviceFormat.sampleRate > 0.0
+            ? deviceFormat.sampleRate / config.sampleRate
+            : 1.0;
+
+        const auto numChannels = engineBuffer.getNumChannels();
+        resamplerIn.prepare(numChannels, deviceToEngineRatio);
+        resamplerOut.prepare(numChannels, engineToDeviceRatio);
+
+        std::vector<const float*> deviceInputs(static_cast<size_t>(numChannels), nullptr);
+        std::vector<float*> engineInputs(static_cast<size_t>(numChannels), nullptr);
+        std::vector<const float*> engineOutputs(static_cast<size_t>(numChannels), nullptr);
+        std::vector<float*> deviceOutputs(static_cast<size_t>(numChannels), nullptr);
+
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            if (ch < numInputChannels && inputChannelData != nullptr)
+                deviceInputs[static_cast<size_t>(ch)] = inputChannelData[ch];
+
+            std::fill(engineIn[static_cast<size_t>(ch)].begin(), engineIn[static_cast<size_t>(ch)].end(), 0.0f);
+            std::fill(engineOut[static_cast<size_t>(ch)].begin(), engineOut[static_cast<size_t>(ch)].end(), 0.0f);
+            engineInputs[static_cast<size_t>(ch)] = engineIn[static_cast<size_t>(ch)].data();
+            engineOutputs[static_cast<size_t>(ch)] = engineOut[static_cast<size_t>(ch)].data();
+
+            if (ch < numOutputChannels && outputChannelData != nullptr)
+                deviceOutputs[static_cast<size_t>(ch)] = outputChannelData[ch];
+        }
+
+        resamplerIn.process(deviceInputs.data(), numSamples, engineInputs.data(), config.blockSize);
+        engineBuffer.clear();
+        for (int ch = 0; ch < numChannels; ++ch)
+            engineBuffer.copyFrom(ch, 0, engineIn[static_cast<size_t>(ch)].data(), config.blockSize);
+
+        if (graph)
+        {
+            graph->prepare();
+            graph->process(engineBuffer);
+        }
+
+        for (int ch = 0; ch < numChannels; ++ch)
+            std::memcpy(engineOut[static_cast<size_t>(ch)].data(), engineBuffer.getReadPointer(ch), sizeof(float) * static_cast<size_t>(config.blockSize));
+
+        resamplerOut.process(engineOutputs.data(), config.blockSize, deviceOutputs.data(), numSamples);
+    }
+
+    void DeviceEngine::audioDeviceAboutToStart(juce::AudioIODevice* device)
+    {
+        if (! device)
+            return;
+
+        deviceFormat.sampleRate = device->getCurrentSampleRate();
+        deviceFormat.blockSize = device->getCurrentBufferSizeSamples();
+
+        ensureBuffers(device->getActiveOutputChannels().countNumberOfSetBits(), config.blockSize);
+    }
+
+    void DeviceEngine::audioDeviceStopped()
+    {
+        engineBuffer.clear();
+    }
+
+    void DeviceEngine::ensureBuffers(int numChannels, int numSamples)
+    {
+        engineBuffer.setSize(numChannels, numSamples, false, false, true);
+        engineIn.resize(static_cast<size_t>(numChannels));
+        engineOut.resize(static_cast<size_t>(numChannels));
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            engineIn[static_cast<size_t>(ch)].resize(static_cast<size_t>(numSamples));
+            engineOut[static_cast<size_t>(ch)].resize(static_cast<size_t>(numSamples));
+        }
+    }
+}

--- a/src/audio/DeviceEngine.h
+++ b/src/audio/DeviceEngine.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <memory>
+
+#include "audio/Resampler.h"
+#include "graph/GraphEngine.h"
+
+namespace host::audio
+{
+    struct EngineConfig
+    {
+        double sampleRate { 48000.0 };
+        int blockSize { 256 };
+    };
+
+    class DeviceEngine : public juce::AudioIODeviceCallback
+    {
+    public:
+        explicit DeviceEngine(std::shared_ptr<host::graph::GraphEngine> graphEngine);
+        ~DeviceEngine() override = default;
+
+        void setConfig(const EngineConfig& cfg);
+        EngineConfig getConfig() const noexcept { return config; }
+
+        void audioDeviceIOCallback(const float* const* inputChannelData,
+                                   int numInputChannels,
+                                   float* const* outputChannelData,
+                                   int numOutputChannels,
+                                   int numSamples) override;
+
+        void audioDeviceAboutToStart(juce::AudioIODevice* device) override;
+        void audioDeviceStopped() override;
+
+    private:
+        void ensureBuffers(int numChannels, int numSamples);
+
+        std::shared_ptr<host::graph::GraphEngine> graph;
+        EngineConfig config;
+        EngineConfig deviceFormat;
+        std::vector<std::vector<float>> engineIn;
+        std::vector<std::vector<float>> engineOut;
+        juce::AudioBuffer<float> engineBuffer;
+        Resampler resamplerIn;
+        Resampler resamplerOut;
+    };
+}

--- a/src/audio/Resampler.cpp
+++ b/src/audio/Resampler.cpp
@@ -1,0 +1,6 @@
+#include "audio/Resampler.h"
+
+namespace host::audio
+{
+    // Intentionally left mostly inline in header for performance. This translation unit ensures the header is part of the build.
+}

--- a/src/audio/Resampler.h
+++ b/src/audio/Resampler.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <juce_dsp/juce_dsp.h>
+#include <memory>
+#include <vector>
+
+namespace host::audio
+{
+    /** Simple per-channel resampler abstraction to allow swapping implementations later. */
+    class Resampler
+    {
+    public:
+        Resampler() = default;
+
+        void prepare(int numChannels, double ratio)
+        {
+            if (channels != numChannels)
+            {
+                resamplers.clear();
+                resamplers.reserve(static_cast<size_t>(numChannels));
+                for (int i = 0; i < numChannels; ++i)
+                    resamplers.emplace_back(std::make_unique<juce::LagrangeInterpolator>());
+                channels = numChannels;
+            }
+
+            resampleRatio = ratio;
+            for (auto& r : resamplers)
+                r->reset();
+        }
+
+        void reset()
+        {
+            for (auto& r : resamplers)
+                r->reset();
+        }
+
+        void process(const float* const* input, int numInputSamples, float* const* output, int numOutputSamples)
+        {
+            JUCE_ASSERT_MESSAGE_MANAGER_ONLY(jassert(resampleRatio > 0.0));
+            if (resamplers.empty())
+                return;
+
+            for (int ch = 0; ch < channels; ++ch)
+            {
+                auto* in = input[ch];
+                auto* out = output[ch];
+                if (! in || ! out)
+                    continue;
+
+                auto& interpolator = *resamplers[static_cast<size_t>(ch)];
+                interpolator.process(resampleRatio, in, out, numOutputSamples);
+            }
+        }
+
+        double getRatio() const noexcept { return resampleRatio; }
+        int getNumChannels() const noexcept { return channels; }
+
+    private:
+        int channels { 0 };
+        double resampleRatio { 1.0 };
+        std::vector<std::unique_ptr<juce::LagrangeInterpolator>> resamplers;
+    };
+}

--- a/src/graph/GraphEngine.cpp
+++ b/src/graph/GraphEngine.cpp
@@ -1,0 +1,145 @@
+#include "graph/GraphEngine.h"
+
+#include <algorithm>
+#include <map>
+#include <queue>
+
+namespace host::graph
+{
+    GraphEngine::GraphEngine() = default;
+    GraphEngine::~GraphEngine() = default;
+
+    void GraphEngine::setEngineFormat(double sampleRate, int blockSize)
+    {
+        currentSampleRate = sampleRate;
+        currentBlockSize = blockSize;
+        needsScheduleRebuild = true;
+    }
+
+    GraphEngine::NodeId GraphEngine::addNode(std::unique_ptr<Node> node)
+    {
+        NodeId id;
+        nodes.emplace(id, std::move(node));
+        needsScheduleRebuild = true;
+        return id;
+    }
+
+    void GraphEngine::removeNode(NodeId id)
+    {
+        nodes.erase(id);
+        connections.erase(std::remove_if(connections.begin(), connections.end(), [id](const Connection& c) {
+            return c.source == id || c.destination == id;
+        }), connections.end());
+        schedule.erase(std::remove(schedule.begin(), schedule.end(), id), schedule.end());
+        needsScheduleRebuild = true;
+    }
+
+    void GraphEngine::clear()
+    {
+        nodes.clear();
+        connections.clear();
+        schedule.clear();
+        audioInputId = {};
+        audioOutputId = {};
+        needsScheduleRebuild = true;
+    }
+
+    bool GraphEngine::connect(NodeId source, NodeId dest)
+    {
+        if (source == dest)
+            return false;
+
+        connections.push_back({ source, dest });
+        needsScheduleRebuild = true;
+        return true;
+    }
+
+    void GraphEngine::disconnect(NodeId source, NodeId dest)
+    {
+        connections.erase(std::remove_if(connections.begin(), connections.end(), [source, dest](const Connection& c) {
+            return c.source == source && c.destination == dest;
+        }), connections.end());
+        needsScheduleRebuild = true;
+    }
+
+    void GraphEngine::setIO(NodeId input, NodeId output)
+    {
+        audioInputId = input;
+        audioOutputId = output;
+    }
+
+    void GraphEngine::prepare()
+    {
+        if (needsScheduleRebuild)
+        {
+            rebuildSchedule();
+            updateLatencyAlignment();
+            needsScheduleRebuild = false;
+        }
+
+        for (auto& [id, node] : nodes)
+            if (node)
+                node->prepare(currentSampleRate, currentBlockSize);
+    }
+
+    void GraphEngine::process(juce::AudioBuffer<float>& buffer)
+    {
+        ProcessContext context { buffer, currentSampleRate, currentBlockSize };
+        for (auto& nodeId : schedule)
+        {
+            if (auto* node = getNode(nodeId))
+                node->process(context);
+        }
+    }
+
+    Node* GraphEngine::getNode(NodeId id) const
+    {
+        if (auto it = nodes.find(id); it != nodes.end())
+            return it->second.get();
+        return nullptr;
+    }
+
+    void GraphEngine::rebuildSchedule()
+    {
+        schedule.clear();
+
+        std::map<NodeId, int> indegree;
+        for (auto& [id, node] : nodes)
+            indegree[id] = 0;
+        for (auto& c : connections)
+            ++indegree[c.destination];
+
+        std::queue<NodeId> q;
+        for (auto& [id, deg] : indegree)
+            if (deg == 0)
+                q.push(id);
+
+        while (! q.empty())
+        {
+            auto id = q.front();
+            q.pop();
+            schedule.push_back(id);
+
+            for (auto& c : connections)
+            {
+                if (c.source == id)
+                {
+                    auto& deg = indegree[c.destination];
+                    if (--deg == 0)
+                        q.push(c.destination);
+                }
+            }
+        }
+    }
+
+    bool GraphEngine::detectCycle(NodeId, std::vector<NodeId>&, std::vector<NodeId>&) const
+    {
+        // TODO: implement proper cycle detection.
+        return false;
+    }
+
+    void GraphEngine::updateLatencyAlignment()
+    {
+        // TODO: implement PDC alignment once latency reporting is hooked up.
+    }
+}

--- a/src/graph/GraphEngine.h
+++ b/src/graph/GraphEngine.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+#include <memory>
+#include <vector>
+#include <map>
+#include <string>
+
+namespace host::graph
+{
+    struct ProcessContext
+    {
+        juce::AudioBuffer<float>& audioBuffer;
+        double sampleRate {};
+        int blockSize {};
+    };
+
+    class Node
+    {
+    public:
+        virtual ~Node() = default;
+        virtual void prepare(double sampleRate, int blockSize) = 0;
+        virtual void process(ProcessContext& context) = 0;
+        virtual int latencySamples() const noexcept { return 0; }
+        virtual std::string name() const = 0;
+    };
+
+    using NodeId = juce::Uuid;
+
+    struct Connection
+    {
+        NodeId source;
+        NodeId destination;
+    };
+
+    class GraphEngine
+    {
+    public:
+        GraphEngine();
+        ~GraphEngine();
+
+        void setEngineFormat(double sampleRate, int blockSize);
+
+        NodeId addNode(std::unique_ptr<Node> node);
+        void removeNode(NodeId id);
+        void clear();
+
+        bool connect(NodeId source, NodeId dest);
+        void disconnect(NodeId source, NodeId dest);
+
+        void setIO(NodeId input, NodeId output);
+
+        void prepare();
+        void process(juce::AudioBuffer<float>& buffer);
+
+        [[nodiscard]] Node* getNode(NodeId id) const;
+        [[nodiscard]] std::vector<NodeId> getSchedule() const { return schedule; }
+
+    private:
+        void rebuildSchedule();
+        bool detectCycle(NodeId node, std::vector<NodeId>& stack, std::vector<NodeId>& visited) const;
+        void updateLatencyAlignment();
+
+        double currentSampleRate { 48000.0 };
+        int currentBlockSize { 256 };
+        std::map<NodeId, std::unique_ptr<Node>> nodes;
+        std::vector<Connection> connections;
+        std::vector<NodeId> schedule;
+        NodeId audioInputId;
+        NodeId audioOutputId;
+        bool needsScheduleRebuild { true };
+    };
+}

--- a/src/graph/Nodes/AudioIn.h
+++ b/src/graph/Nodes/AudioIn.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+namespace host::graph::nodes
+{
+    class AudioInNode : public Node
+    {
+    public:
+        void prepare(double, int) override {}
+
+        void process(ProcessContext&) override {}
+
+        std::string name() const override { return "Audio In"; }
+    };
+}

--- a/src/graph/Nodes/AudioOut.h
+++ b/src/graph/Nodes/AudioOut.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+namespace host::graph::nodes
+{
+    class AudioOutNode : public Node
+    {
+    public:
+        void prepare(double, int) override {}
+
+        void process(ProcessContext&) override {}
+
+        std::string name() const override { return "Audio Out"; }
+    };
+}

--- a/src/graph/Nodes/Gain.h
+++ b/src/graph/Nodes/Gain.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+#include <atomic>
+
+namespace host::graph::nodes
+{
+    class GainNode : public Node
+    {
+    public:
+        void setGain(float newGain) noexcept { gain.store(newGain); }
+
+        void prepare(double, int) override {}
+
+        void process(ProcessContext& context) override
+        {
+            auto currentGain = gain.load();
+            context.audioBuffer.applyGain(currentGain);
+        }
+
+        std::string name() const override { return "Gain"; }
+
+    private:
+        std::atomic<float> gain { 1.0f };
+    };
+}

--- a/src/graph/Nodes/Merge.h
+++ b/src/graph/Nodes/Merge.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+namespace host::graph::nodes
+{
+    class MergeNode : public Node
+    {
+    public:
+        void prepare(double, int) override {}
+
+        void process(ProcessContext& context) override
+        {
+            juce::ignoreUnused(context);
+        }
+
+        std::string name() const override { return "Merge"; }
+    };
+}

--- a/src/graph/Nodes/Mix.h
+++ b/src/graph/Nodes/Mix.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+namespace host::graph::nodes
+{
+    class MixNode : public Node
+    {
+    public:
+        void prepare(double, int) override {}
+
+        void process(ProcessContext& context) override
+        {
+            // TODO: implement multi-input mixing. For now, acts as a passthrough.
+            juce::ignoreUnused(context);
+        }
+
+        std::string name() const override { return "Mix"; }
+    };
+}

--- a/src/graph/Nodes/Split.h
+++ b/src/graph/Nodes/Split.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+
+namespace host::graph::nodes
+{
+    class SplitNode : public Node
+    {
+    public:
+        void prepare(double, int) override {}
+
+        void process(ProcessContext& context) override
+        {
+            juce::ignoreUnused(context);
+        }
+
+        std::string name() const override { return "Split"; }
+    };
+}

--- a/src/graph/Nodes/VstFx.h
+++ b/src/graph/Nodes/VstFx.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "graph/GraphEngine.h"
+#include "host/PluginHost.h"
+
+namespace host::graph::nodes
+{
+    class VstFxNode : public Node
+    {
+    public:
+        explicit VstFxNode(std::shared_ptr<host::plugin::PluginInstance> instance)
+            : plugin(std::move(instance))
+        {
+        }
+
+        void prepare(double sampleRate, int blockSize) override
+        {
+            if (plugin)
+                plugin->prepare(sampleRate, blockSize);
+        }
+
+        void process(ProcessContext& context) override
+        {
+            if (plugin)
+                plugin->process(context.audioBuffer);
+        }
+
+        int latencySamples() const noexcept override
+        {
+            return plugin ? plugin->getLatencySamples() : 0;
+        }
+
+        std::string name() const override
+        {
+            return plugin ? plugin->getName() : "VST FX";
+        }
+
+        std::shared_ptr<host::plugin::PluginInstance> getPlugin() const noexcept { return plugin; }
+
+    private:
+        std::shared_ptr<host::plugin::PluginInstance> plugin;
+    };
+}

--- a/src/gui/GraphView.cpp
+++ b/src/gui/GraphView.cpp
@@ -1,0 +1,56 @@
+#include "gui/GraphView.h"
+
+namespace host::gui
+{
+    GraphView::GraphView()
+    {
+        setInterceptsMouseClicks(true, true);
+    }
+
+    void GraphView::setGraph(std::shared_ptr<host::graph::GraphEngine> graphEngine)
+    {
+        graph = std::move(graphEngine);
+        repaint();
+    }
+
+    void GraphView::paint(juce::Graphics& g)
+    {
+        g.fillAll(juce::Colours::darkgrey);
+
+        if (! graph)
+        {
+            g.setColour(juce::Colours::white);
+            g.setFont(16.0f);
+            g.drawText("Graph is empty", getLocalBounds(), juce::Justification::centred);
+            return;
+        }
+
+        auto schedule = graph->getSchedule();
+        const auto nodeWidth = 140;
+        const auto nodeHeight = 60;
+        const auto spacing = 20;
+
+        g.setFont(14.0f);
+        int x = spacing;
+        int y = getHeight() / 2 - nodeHeight / 2;
+
+        for (auto& id : schedule)
+        {
+            if (auto* node = graph->getNode(id))
+            {
+                juce::Rectangle<int> bounds(x, y, nodeWidth, nodeHeight);
+                g.setColour(juce::Colours::black.withAlpha(0.6f));
+                g.fillRoundedRectangle(bounds.toFloat(), 8.0f);
+                g.setColour(juce::Colours::orange);
+                g.drawRoundedRectangle(bounds.toFloat(), 8.0f, 2.0f);
+                g.setColour(juce::Colours::white);
+                g.drawFittedText(juce::String(node->name()), bounds.reduced(10), juce::Justification::centred, 2);
+                x += nodeWidth + spacing;
+            }
+        }
+    }
+
+    void GraphView::resized()
+    {
+    }
+}

--- a/src/gui/GraphView.h
+++ b/src/gui/GraphView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <memory>
+
+#include "graph/GraphEngine.h"
+
+namespace host::gui
+{
+    class GraphView : public juce::Component
+    {
+    public:
+        GraphView();
+        ~GraphView() override = default;
+
+        void setGraph(std::shared_ptr<host::graph::GraphEngine> graphEngine);
+
+        void paint(juce::Graphics& g) override;
+        void resized() override;
+
+    private:
+        std::shared_ptr<host::graph::GraphEngine> graph;
+    };
+}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,0 +1,185 @@
+#include "gui/MainWindow.h"
+
+#include "graph/Nodes/AudioIn.h"
+#include "graph/Nodes/AudioOut.h"
+#include "persist/Project.h"
+
+namespace
+{
+    enum MenuItem
+    {
+        menuOpen = 1,
+        menuSave,
+        menuPreferences,
+        menuDeviceSelector,
+        menuRescan
+    };
+}
+
+MainWindow::MainWindow()
+    : juce::DocumentWindow("VST Host Scaffold", juce::Colours::darkgrey, juce::DocumentWindow::allButtons),
+      graphEngine(std::make_shared<host::graph::GraphEngine>()),
+      pluginScanner(std::make_shared<host::plugin::PluginScanner>()),
+      deviceEngine(graphEngine)
+{
+    setUsingNativeTitleBar(true);
+    setResizable(true, true);
+
+    deviceManager.initialise(0, 2, nullptr, true);
+    deviceManager.addAudioCallback(&deviceEngine);
+    deviceEngine.setConfig({ 48000.0, 256 });
+
+    pluginBrowser.setScanner(pluginScanner);
+    graphView.setGraph(graphEngine);
+
+    leftPanel.addAndMakeVisible(pluginBrowser);
+    rightPanel.addAndMakeVisible(graphView);
+
+    layoutManager.setItemLayout(0, 200, 400, 260);
+    layoutManager.setItemLayout(1, 4, 8, 6);
+    layoutManager.setItemLayout(2, 200, -0.9, -0.9);
+
+    auto* content = new juce::Component();
+    content->addAndMakeVisible(leftPanel);
+    content->addAndMakeVisible(resizerBar);
+    content->addAndMakeVisible(rightPanel);
+    setContentOwned(content, true);
+
+    setMenuBar(this);
+
+    initialiseGraph();
+
+    setCentrePosition(200, 200);
+    setSize(1024, 768);
+    setVisible(true);
+}
+
+MainWindow::~MainWindow()
+{
+    setMenuBar(nullptr);
+    deviceManager.removeAudioCallback(&deviceEngine);
+}
+
+void MainWindow::closeButtonPressed()
+{
+    juce::JUCEApplication::getInstance()->systemRequestedQuit();
+}
+
+void MainWindow::resized()
+{
+    juce::DocumentWindow::resized();
+
+    if (auto* content = getContentComponent())
+    {
+        auto area = content->getLocalBounds();
+        juce::Component* comps[] = { &leftPanel, &resizerBar, &rightPanel };
+        layoutManager.layOutComponents(comps, 3, area.getX(), area.getY(), area.getWidth(), area.getHeight(), false, true);
+        pluginBrowser.setBounds(leftPanel.getLocalBounds());
+        graphView.setBounds(rightPanel.getLocalBounds());
+    }
+}
+
+juce::StringArray MainWindow::getMenuBarNames()
+{
+    return { "File", "Edit", "View" };
+}
+
+juce::PopupMenu MainWindow::getMenuForIndex(int menuIndex, const juce::String&)
+{
+    juce::PopupMenu menu;
+
+    if (menuIndex == 0)
+    {
+        menu.addItem(menuOpen, "Open Project...");
+        menu.addItem(menuSave, "Save Project");
+        menu.addSeparator();
+        menu.addItem(menuDeviceSelector, "Audio Device Setup...");
+        menu.addItem(menuPreferences, "Preferences...");
+    }
+    else if (menuIndex == 1)
+    {
+        menu.addItem(menuRescan, "Rescan Plugins");
+    }
+
+    return menu;
+}
+
+void MainWindow::menuItemSelected(int menuItemID, int)
+{
+    switch (menuItemID)
+    {
+        case menuOpen:      loadProject(); break;
+        case menuSave:      saveProject(); break;
+        case menuPreferences: openPreferences(); break;
+        case menuDeviceSelector: showDeviceSelector(); break;
+        case menuRescan:
+            if (pluginScanner)
+                pluginScanner->scanAsync();
+            break;
+        default:
+            break;
+    }
+}
+
+void MainWindow::initialiseGraph()
+{
+    graphEngine->clear();
+    graphEngine->setEngineFormat(48000.0, 256);
+
+    auto inputId = graphEngine->addNode(std::make_unique<host::graph::nodes::AudioInNode>());
+    auto outputId = graphEngine->addNode(std::make_unique<host::graph::nodes::AudioOutNode>());
+
+    graphEngine->setIO(inputId, outputId);
+    graphEngine->connect(inputId, outputId);
+    graphEngine->prepare();
+}
+
+void MainWindow::openPreferences()
+{
+    juce::DialogWindow::LaunchOptions options;
+    options.content.reset(new PreferencesComponent(deviceEngine, pluginScanner));
+    options.dialogTitle = "Preferences";
+    options.componentToCentreAround = this;
+    options.useNativeTitleBar = true;
+    options.resizable = true;
+    options.runModal();
+}
+
+void MainWindow::showDeviceSelector()
+{
+    juce::AudioDeviceSelectorComponent selector(deviceManager, 0, 2, 0, 2, true, true, true, false);
+    selector.setSize(500, 400);
+
+    juce::DialogWindow::LaunchOptions options;
+    options.content.setNonOwned(&selector);
+    options.dialogTitle = "Audio Device Settings";
+    options.componentToCentreAround = this;
+    options.useNativeTitleBar = true;
+    options.resizable = false;
+    options.runModal();
+}
+
+void MainWindow::loadProject()
+{
+    juce::FileChooser chooser("Open project", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
+    if (! chooser.browseForFileToOpen())
+        return;
+
+    auto file = chooser.getResult();
+    host::persist::Project project;
+    if (project.load(file))
+    {
+        // TODO: reconstruct graph and plugins from project description.
+    }
+}
+
+void MainWindow::saveProject()
+{
+    juce::FileChooser chooser("Save project", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
+    if (! chooser.browseForFileToSave(true))
+        return;
+
+    host::persist::Project project;
+    project.save(chooser.getResult(), *graphEngine);
+}
+*** End Patch

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+
+#include "audio/DeviceEngine.h"
+#include "graph/GraphEngine.h"
+#include "gui/GraphView.h"
+#include "gui/PluginBrowser.h"
+#include "gui/Preferences.h"
+#include "host/PluginScanner.h"
+
+class MainWindow : public juce::DocumentWindow,
+                   private juce::MenuBarModel
+{
+public:
+    MainWindow();
+    ~MainWindow() override;
+
+    void closeButtonPressed() override;
+    void resized() override;
+
+private:
+    juce::StringArray getMenuBarNames() override;
+    juce::PopupMenu getMenuForIndex(int menuIndex, const juce::String& menuName) override;
+    void menuItemSelected(int menuItemID, int topLevelMenuIndex) override;
+
+    void initialiseGraph();
+    void openPreferences();
+    void showDeviceSelector();
+    void loadProject();
+    void saveProject();
+
+    std::shared_ptr<host::graph::GraphEngine> graphEngine;
+    std::shared_ptr<host::plugin::PluginScanner> pluginScanner;
+    host::audio::DeviceEngine deviceEngine;
+    juce::AudioDeviceManager deviceManager;
+
+    std::unique_ptr<juce::MenuBarComponent> menuBar;
+    host::gui::GraphView graphView;
+    host::gui::PluginBrowser pluginBrowser;
+    juce::StretchableLayoutManager layoutManager;
+    juce::StretchableLayoutResizerBar resizerBar { &layoutManager, 1, true };
+    juce::Component leftPanel;
+    juce::Component rightPanel;
+};

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -1,0 +1,94 @@
+#include "gui/PluginBrowser.h"
+
+namespace host::gui
+{
+    PluginBrowser::PluginBrowser()
+    {
+        addAndMakeVisible(searchBox);
+        addAndMakeVisible(listBox);
+
+        listBox.setModel(this);
+        searchBox.setTextToShowWhenEmpty("Search plugins", juce::Colours::grey);
+        searchBox.onTextChange = [this]
+        {
+            filterPlugins();
+        };
+    }
+
+    PluginBrowser::~PluginBrowser()
+    {
+        if (pluginScanner)
+            pluginScanner->removeChangeListener(this);
+    }
+
+    void PluginBrowser::setScanner(std::shared_ptr<host::plugin::PluginScanner> scanner)
+    {
+        if (pluginScanner)
+            pluginScanner->removeChangeListener(this);
+
+        pluginScanner = std::move(scanner);
+
+        if (pluginScanner)
+            pluginScanner->addChangeListener(this);
+
+        filterPlugins();
+    }
+
+    void PluginBrowser::paint(juce::Graphics& g)
+    {
+        g.fillAll(juce::Colours::darkgrey.darker(0.4f));
+    }
+
+    void PluginBrowser::resized()
+    {
+        auto area = getLocalBounds();
+        searchBox.setBounds(area.removeFromTop(28).reduced(4));
+        listBox.setBounds(area);
+    }
+
+    int PluginBrowser::getNumRows()
+    {
+        return static_cast<int>(filteredPlugins.size());
+    }
+
+    void PluginBrowser::paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected)
+    {
+        if (row < 0 || row >= getNumRows())
+            return;
+
+        auto& info = filteredPlugins[static_cast<size_t>(row)];
+        auto bounds = juce::Rectangle<int>(0, 0, width, height);
+
+        g.setColour(rowIsSelected ? juce::Colours::darkorange : juce::Colours::transparentBlack);
+        g.fillRect(bounds);
+
+        g.setColour(juce::Colours::white);
+        auto label = juce::String(info.name) + " (" + (info.format == host::plugin::PluginFormat::VST3 ? "VST3" : "VST2") + ")";
+        g.drawFittedText(label, bounds.reduced(8), juce::Justification::centredLeft, 1);
+    }
+
+    void PluginBrowser::changeListenerCallback(juce::ChangeBroadcaster* source)
+    {
+        if (source == pluginScanner.get())
+            filterPlugins();
+    }
+
+    void PluginBrowser::filterPlugins()
+    {
+        filteredPlugins.clear();
+        if (! pluginScanner)
+            return;
+
+        auto text = searchBox.getText().toLowerCase();
+        auto list = pluginScanner->getDiscoveredPlugins();
+        for (const auto& info : list)
+        {
+            auto loweredName = juce::String(info.name).toLowerCase();
+            if (text.isEmpty() || loweredName.contains(text))
+                filteredPlugins.push_back(info);
+        }
+
+        listBox.updateContent();
+        listBox.repaint();
+    }
+}

--- a/src/gui/PluginBrowser.h
+++ b/src/gui/PluginBrowser.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include "host/PluginScanner.h"
+#include <memory>
+#include <vector>
+
+namespace host::gui
+{
+    class PluginBrowser : public juce::Component,
+                          private juce::ListBoxModel,
+                          private juce::ChangeListener
+    {
+    public:
+        PluginBrowser();
+        ~PluginBrowser() override;
+
+        void setScanner(std::shared_ptr<host::plugin::PluginScanner> scanner);
+
+        void paint(juce::Graphics& g) override;
+        void resized() override;
+
+    private:
+        int getNumRows() override;
+        void paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected) override;
+        void changeListenerCallback(juce::ChangeBroadcaster* source) override;
+        void filterPlugins();
+
+        std::shared_ptr<host::plugin::PluginScanner> pluginScanner;
+        juce::TextEditor searchBox;
+        juce::ListBox listBox { "Plugins", this };
+        std::vector<host::plugin::PluginInfo> filteredPlugins;
+    };
+}

--- a/src/gui/Preferences.cpp
+++ b/src/gui/Preferences.cpp
@@ -1,0 +1,172 @@
+#include "gui/Preferences.h"
+
+namespace host::gui
+{
+    PreferencesComponent::PreferencesComponent(host::audio::DeviceEngine& engine,
+                                               std::shared_ptr<host::plugin::PluginScanner> scanner)
+        : deviceEngine(engine), pluginScanner(std::move(scanner))
+    {
+        addAndMakeVisible(tabs);
+        buildAudioTab();
+        buildPluginTab();
+        pluginPathList.setRowHeight(24);
+    }
+
+    void PreferencesComponent::paint(juce::Graphics& g)
+    {
+        g.fillAll(juce::Colours::darkgrey);
+    }
+
+    void PreferencesComponent::resized()
+    {
+        tabs.setBounds(getLocalBounds().reduced(10));
+        layoutAudioTab();
+        layoutPluginTab();
+    }
+
+    void PreferencesComponent::buildAudioTab()
+    {
+        audioTab = new juce::Component();
+        audioTab->addAndMakeVisible(driverBox);
+        audioTab->addAndMakeVisible(deviceBox);
+        audioTab->addAndMakeVisible(engineSampleRateBox);
+        audioTab->addAndMakeVisible(engineBlockBox);
+
+        tabs.addTab("Audio", juce::Colours::grey, audioTab, true);
+
+        driverBox.addItem("ASIO", 1);
+        driverBox.addItem("WASAPI", 2);
+        driverBox.setSelectedId(1);
+
+        engineSampleRateBox.addItem("44100", 1);
+        engineSampleRateBox.addItem("48000", 2);
+        engineSampleRateBox.addItem("96000", 3);
+        engineSampleRateBox.setSelectedId(2);
+        engineSampleRateBox.onChange = [this]
+        {
+            auto cfg = deviceEngine.getConfig();
+            cfg.sampleRate = engineSampleRateBox.getText().getDoubleValue();
+            deviceEngine.setConfig(cfg);
+        };
+
+        engineBlockBox.addItem("128", 1);
+        engineBlockBox.addItem("256", 2);
+        engineBlockBox.addItem("512", 3);
+        engineBlockBox.setSelectedId(2);
+        engineBlockBox.onChange = [this]
+        {
+            auto cfg = deviceEngine.getConfig();
+            cfg.blockSize = engineBlockBox.getText().getIntValue();
+            deviceEngine.setConfig(cfg);
+        };
+
+        refreshDeviceList();
+    }
+
+    void PreferencesComponent::buildPluginTab()
+    {
+        pluginTab = new juce::Component();
+        pluginTab->addAndMakeVisible(pluginPathList);
+        pluginTab->addAndMakeVisible(addPathButton);
+        pluginTab->addAndMakeVisible(removePathButton);
+        pluginTab->addAndMakeVisible(rescanButton);
+
+        tabs.addTab("Plugins", juce::Colours::grey, pluginTab, true);
+
+        if (pluginScanner)
+        {
+            pluginPaths.clear();
+            for (auto& path : pluginScanner->getSearchPaths())
+                pluginPaths.push_back(path);
+        }
+
+        pluginPathList.updateContent();
+
+        addPathButton.onClick = [this]
+        {
+            juce::FileChooser chooser("Select plugin directory", juce::File::getSpecialLocation(juce::File::userHomeDirectory));
+            if (chooser.browseForDirectory())
+            {
+                auto dir = chooser.getResult();
+                pluginPaths.push_back(dir);
+                if (pluginScanner)
+                    pluginScanner->addSearchPath(dir);
+                pluginPathList.updateContent();
+                pluginPathList.repaint();
+            }
+        };
+
+        removePathButton.onClick = [this]
+        {
+            auto selected = pluginPathList.getSelectedRow();
+            if (selected >= 0 && selected < static_cast<int>(pluginPaths.size()))
+            {
+                auto file = pluginPaths[static_cast<size_t>(selected)];
+                pluginPaths.erase(pluginPaths.begin() + selected);
+                if (pluginScanner)
+                    pluginScanner->removeSearchPath(file);
+                pluginPathList.updateContent();
+                pluginPathList.repaint();
+            }
+        };
+
+        rescanButton.onClick = [this]
+        {
+            if (pluginScanner)
+                pluginScanner->scanAsync();
+        };
+    }
+
+    void PreferencesComponent::layoutAudioTab()
+    {
+        if (audioTab == nullptr)
+            return;
+
+        auto area = audioTab->getLocalBounds().reduced(20);
+        auto lineHeight = 32;
+        driverBox.setBounds(area.removeFromTop(lineHeight));
+        area.removeFromTop(10);
+        deviceBox.setBounds(area.removeFromTop(lineHeight));
+        area.removeFromTop(10);
+        engineSampleRateBox.setBounds(area.removeFromTop(lineHeight));
+        area.removeFromTop(10);
+        engineBlockBox.setBounds(area.removeFromTop(lineHeight));
+    }
+
+    void PreferencesComponent::layoutPluginTab()
+    {
+        if (pluginTab == nullptr)
+            return;
+
+        auto area = pluginTab->getLocalBounds().reduced(10);
+        auto controls = area.removeFromBottom(32);
+        addPathButton.setBounds(controls.removeFromLeft(100).reduced(2));
+        removePathButton.setBounds(controls.removeFromLeft(100).reduced(2));
+        rescanButton.setBounds(controls.removeFromLeft(100).reduced(2));
+        pluginPathList.setBounds(area);
+    }
+
+    void PreferencesComponent::refreshDeviceList()
+    {
+        deviceBox.clear();
+        deviceBox.addItem("Default Device", 1);
+        deviceBox.setSelectedId(1);
+    }
+
+    int PreferencesComponent::getNumRows()
+    {
+        return static_cast<int>(pluginPaths.size());
+    }
+
+    void PreferencesComponent::paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected)
+    {
+        if (row < 0 || row >= getNumRows())
+            return;
+
+        auto bounds = juce::Rectangle<int>(0, 0, width, height);
+        g.setColour(rowIsSelected ? juce::Colours::darkorange : juce::Colours::transparentBlack);
+        g.fillRect(bounds);
+        g.setColour(juce::Colours::white);
+        g.drawText(pluginPaths[static_cast<size_t>(row)].getFullPathName(), bounds.reduced(4), juce::Justification::centredLeft);
+    }
+}

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <vector>
+
+#include "audio/DeviceEngine.h"
+#include "host/PluginScanner.h"
+
+namespace host::gui
+{
+    class PreferencesComponent : public juce::Component,
+                                 private juce::ListBoxModel
+    {
+    public:
+        PreferencesComponent(host::audio::DeviceEngine& engine,
+                             std::shared_ptr<host::plugin::PluginScanner> scanner);
+
+        void paint(juce::Graphics& g) override;
+        void resized() override;
+
+    private:
+        void buildAudioTab();
+        void buildPluginTab();
+        void refreshDeviceList();
+        void layoutAudioTab();
+        void layoutPluginTab();
+        int getNumRows() override;
+        void paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected) override;
+
+        host::audio::DeviceEngine& deviceEngine;
+        std::shared_ptr<host::plugin::PluginScanner> pluginScanner;
+
+        juce::TabbedComponent tabs { juce::TabbedButtonBar::TabsAtTop };
+        juce::Component* audioTab { nullptr };
+        juce::Component* pluginTab { nullptr };
+        juce::ComboBox driverBox;
+        juce::ComboBox deviceBox;
+        juce::ComboBox engineSampleRateBox;
+        juce::ComboBox engineBlockBox;
+        juce::ListBox pluginPathList { "PluginPaths", this };
+        juce::TextButton addPathButton { "Add" };
+        juce::TextButton removePathButton { "Remove" };
+        juce::TextButton rescanButton { "Rescan" };
+        std::vector<juce::File> pluginPaths;
+    };
+}

--- a/src/host/PluginHost.cpp
+++ b/src/host/PluginHost.cpp
@@ -1,0 +1,77 @@
+#include "host/PluginHost.h"
+
+#include <utility>
+
+namespace host::plugin
+{
+    VST3PluginInstance::VST3PluginInstance(std::unique_ptr<juce::AudioPluginInstance> instance)
+        : plugin(std::move(instance))
+    {
+    }
+
+    void VST3PluginInstance::prepare(double sampleRate, int blockSize)
+    {
+        if (plugin)
+            plugin->prepareToPlay(sampleRate, blockSize);
+    }
+
+    void VST3PluginInstance::process(juce::AudioBuffer<float>& buffer)
+    {
+        if (! plugin)
+            return;
+
+        juce::MidiBuffer midi;
+        plugin->processBlock(buffer, midi);
+    }
+
+    int VST3PluginInstance::getLatencySamples() const noexcept
+    {
+        return plugin ? plugin->getLatencySamples() : 0;
+    }
+
+    std::string VST3PluginInstance::getName() const
+    {
+        return plugin ? plugin->getName().toStdString() : std::string{};
+    }
+
+    juce::MemoryBlock VST3PluginInstance::getState() const
+    {
+        juce::MemoryBlock block;
+        if (plugin)
+            plugin->getStateInformation(block);
+        return block;
+    }
+
+    void VST3PluginInstance::setState(const void* data, size_t size)
+    {
+        if (plugin)
+            plugin->setStateInformation(data, static_cast<int>(size));
+    }
+
+    std::shared_ptr<PluginInstance> loadPlugin(const PluginInfo& info, juce::AudioPluginFormatManager& formatManager, juce::String& error)
+    {
+        error.clear();
+
+        juce::PluginDescription desc;
+        desc.fileOrIdentifier = info.path;
+        desc.name = info.name;
+        desc.pluginFormatName = info.format == PluginFormat::VST3 ? "VST3" : "VST";
+
+        std::unique_ptr<juce::AudioPluginInstance> instance(formatManager.createPluginInstance(desc, 48000.0, 512, error));
+        if (! instance)
+            return nullptr;
+
+        if (info.format == PluginFormat::VST3)
+            return std::make_shared<VST3PluginInstance>(std::move(instance));
+
+    #if ENABLE_VST2
+        // TODO: wrap VST2 instance into a PluginInstance implementation.
+        juce::ignoreUnused(error);
+        return std::make_shared<VST3PluginInstance>(std::move(instance));
+    #else
+        juce::ignoreUnused(instance);
+        error = "VST2 support disabled";
+        return nullptr;
+    #endif
+    }
+}

--- a/src/host/PluginHost.h
+++ b/src/host/PluginHost.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace host::plugin
+{
+    enum class PluginFormat
+    {
+        VST3,
+        VST2
+    };
+
+    struct PluginInfo
+    {
+        std::string identifier;
+        std::string name;
+        PluginFormat format;
+        std::string path;
+        std::vector<std::string> categories;
+        int numInputs { 0 };
+        int numOutputs { 0 };
+        int latency { 0 };
+    };
+
+    class PluginInstance
+    {
+    public:
+        virtual ~PluginInstance() = default;
+        virtual void prepare(double sampleRate, int blockSize) = 0;
+        virtual void process(juce::AudioBuffer<float>& buffer) = 0;
+        virtual int getLatencySamples() const noexcept = 0;
+        virtual std::string getName() const = 0;
+        virtual juce::MemoryBlock getState() const = 0;
+        virtual void setState(const void* data, size_t size) = 0;
+    };
+
+    class VST3PluginInstance : public PluginInstance
+    {
+    public:
+        explicit VST3PluginInstance(std::unique_ptr<juce::AudioPluginInstance> instance);
+
+        void prepare(double sampleRate, int blockSize) override;
+        void process(juce::AudioBuffer<float>& buffer) override;
+        int getLatencySamples() const noexcept override;
+        std::string getName() const override;
+        juce::MemoryBlock getState() const override;
+        void setState(const void* data, size_t size) override;
+
+    private:
+        std::unique_ptr<juce::AudioPluginInstance> plugin;
+    };
+
+    std::shared_ptr<PluginInstance> loadPlugin(const PluginInfo& info, juce::AudioPluginFormatManager& formatManager, juce::String& error);
+}

--- a/src/host/PluginScanner.cpp
+++ b/src/host/PluginScanner.cpp
@@ -1,0 +1,182 @@
+#include "host/PluginScanner.h"
+
+#include <thread>
+#include <vector>
+
+namespace host::plugin
+{
+    namespace
+    {
+        bool hasPluginExtension(const juce::File& file)
+        {
+            auto ext = file.getFileExtension().toLowerCase();
+            return ext == ".vst3" || ext == ".dll";
+        }
+    }
+
+    PluginScanner::PluginScanner() = default;
+
+    void PluginScanner::addSearchPath(const juce::File& path)
+    {
+        if (! path.exists())
+            return;
+
+        const juce::ScopedLock lock(stateLock);
+        if (! searchPaths.contains(path))
+            searchPaths.add(path);
+    }
+
+    void PluginScanner::removeSearchPath(const juce::File& path)
+    {
+        const juce::ScopedLock lock(stateLock);
+        searchPaths.removeFirstMatchingValue(path);
+    }
+
+    void PluginScanner::scanAsync()
+    {
+        if (scanning.exchange(true))
+            return;
+
+        std::thread([this]
+        {
+            runScan();
+            scanning.store(false);
+            sendChangeMessage();
+        }).detach();
+    }
+
+    void PluginScanner::cancelScan()
+    {
+        scanning.store(false);
+    }
+
+    std::vector<PluginInfo> PluginScanner::getDiscoveredPlugins() const
+    {
+        const juce::ScopedLock lock(stateLock);
+        return discovered;
+    }
+
+    bool PluginScanner::loadCache(const juce::File& cacheFile)
+    {
+        cacheLocation = cacheFile;
+        if (! cacheFile.existsAsFile())
+            return false;
+
+        juce::String jsonText = cacheFile.loadFileAsString();
+        juce::var value;
+        auto result = juce::JSON::parse(jsonText, value);
+        if (result.failed())
+        {
+            lastError = result.getErrorMessage();
+            return false;
+        }
+
+        std::vector<PluginInfo> loaded;
+
+        if (auto* object = value.getDynamicObject())
+        {
+            auto list = object->getProperty("plugins");
+            if (auto* arr = list.getArray())
+            {
+                for (auto& pluginVar : *arr)
+                {
+                    PluginInfo info;
+                    if (auto* obj = pluginVar.getDynamicObject())
+                    {
+                        info.identifier = obj->getProperty("id").toString().toStdString();
+                        info.name = obj->getProperty("name").toString().toStdString();
+                        info.format = obj->getProperty("format").toString() == "VST2" ? PluginFormat::VST2 : PluginFormat::VST3;
+                        info.path = obj->getProperty("path").toString().toStdString();
+                        info.numInputs = static_cast<int>(obj->getProperty("ins"));
+                        info.numOutputs = static_cast<int>(obj->getProperty("outs"));
+                        info.latency = static_cast<int>(obj->getProperty("latency"));
+                        if (auto category = obj->getProperty("category").toString(); category.isNotEmpty())
+                            info.categories = { category.toStdString() };
+                    }
+                    loaded.push_back(info);
+                }
+            }
+        }
+
+        {
+            const juce::ScopedLock lock(stateLock);
+            discovered = std::move(loaded);
+        }
+
+        return true;
+    }
+
+    bool PluginScanner::saveCache(const juce::File& cacheFile) const
+    {
+        juce::DynamicObject::Ptr root(new juce::DynamicObject());
+        root->setProperty("v", 1);
+        root->setProperty("scannedAt", juce::Time::getCurrentTime().toISO8601(true));
+
+        juce::Array<juce::var> pluginArray;
+        std::vector<PluginInfo> snapshot;
+        {
+            const juce::ScopedLock lock(stateLock);
+            snapshot = discovered;
+        }
+
+        for (const auto& info : snapshot)
+        {
+            juce::DynamicObject::Ptr obj(new juce::DynamicObject());
+            obj->setProperty("id", info.identifier);
+            obj->setProperty("name", info.name);
+            obj->setProperty("format", info.format == PluginFormat::VST3 ? "VST3" : "VST2");
+            obj->setProperty("path", info.path);
+            obj->setProperty("ins", info.numInputs);
+            obj->setProperty("outs", info.numOutputs);
+            obj->setProperty("latency", info.latency);
+            obj->setProperty("category", info.categories.empty() ? juce::String() : juce::String(info.categories.front()));
+            obj->setProperty("blacklisted", false);
+            juce::var pluginVar(obj.get());
+            pluginArray.add(pluginVar);
+        }
+
+        root->setProperty("plugins", juce::var(pluginArray));
+        auto jsonString = juce::JSON::toString(juce::var(root.get()), true);
+        return cacheFile.replaceWithText(jsonString);
+    }
+
+    void PluginScanner::runScan()
+    {
+        std::vector<PluginInfo> results;
+
+        juce::Array<juce::File> pathsCopy;
+        {
+            const juce::ScopedLock lock(stateLock);
+            pathsCopy = searchPaths;
+        }
+
+        for (auto& path : pathsCopy)
+        {
+            juce::DirectoryIterator it(path, true, "*", juce::File::findFiles);
+            while (it.next())
+            {
+                auto file = it.getFile();
+                if (! hasPluginExtension(file))
+                    continue;
+
+                PluginInfo info;
+                info.path = file.getFullPathName().toStdString();
+                info.name = file.getFileNameWithoutExtension().toStdString();
+                info.identifier = juce::Uuid().toString().toStdString();
+                info.format = file.hasFileExtension(".dll") ? PluginFormat::VST2 : PluginFormat::VST3;
+                info.numInputs = 2;
+                info.numOutputs = 2;
+                info.categories = { "Effect" };
+                results.push_back(std::move(info));
+            }
+        }
+
+        {
+            const juce::ScopedLock lock(stateLock);
+            discovered = std::move(results);
+        }
+
+        if (cacheLocation.existsAsFile())
+            saveCache(cacheLocation);
+    }
+}

--- a/src/host/PluginScanner.h
+++ b/src/host/PluginScanner.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "host/PluginHost.h"
+
+#include <juce_core/juce_core.h>
+#include <atomic>
+
+namespace host::plugin
+{
+    class PluginScanner : public juce::ChangeBroadcaster
+    {
+    public:
+        PluginScanner();
+
+        void addSearchPath(const juce::File& path);
+        void removeSearchPath(const juce::File& path);
+        const juce::Array<juce::File>& getSearchPaths() const noexcept { return searchPaths; }
+
+        void scanAsync();
+        void cancelScan();
+
+        std::vector<PluginInfo> getDiscoveredPlugins() const;
+
+        bool loadCache(const juce::File& cacheFile);
+        bool saveCache(const juce::File& cacheFile) const;
+
+    private:
+        void runScan();
+
+        juce::Array<juce::File> searchPaths;
+        std::vector<PluginInfo> discovered;
+        juce::CriticalSection stateLock;
+        juce::String lastError;
+        juce::File cacheLocation;
+        std::atomic<bool> scanning { false };
+    };
+}

--- a/src/persist/Config.cpp
+++ b/src/persist/Config.cpp
@@ -1,0 +1,51 @@
+#include "persist/Config.h"
+
+namespace host::persist
+{
+    void Config::setPluginDirectories(const std::vector<juce::File>& dirs)
+    {
+        pluginDirectories = dirs;
+    }
+
+    bool Config::load(const juce::File& file)
+    {
+        if (! file.existsAsFile())
+            return false;
+
+        juce::String jsonText = file.loadFileAsString();
+        juce::var root;
+        auto result = juce::JSON::parse(jsonText, root);
+        if (result.failed())
+            return false;
+
+        if (auto* object = root.getDynamicObject())
+        {
+            engineSettings.sampleRate = object->getProperty("sampleRate");
+            engineSettings.blockSize = static_cast<int>(object->getProperty("blockSize"));
+
+            pluginDirectories.clear();
+            if (auto* arr = object->getProperty("pluginDirectories").getArray())
+            {
+                for (auto& entry : *arr)
+                    pluginDirectories.emplace_back(entry.toString());
+            }
+        }
+
+        return true;
+    }
+
+    bool Config::save(const juce::File& file) const
+    {
+        juce::DynamicObject::Ptr obj(new juce::DynamicObject());
+        obj->setProperty("sampleRate", engineSettings.sampleRate);
+        obj->setProperty("blockSize", engineSettings.blockSize);
+
+        juce::Array<juce::var> directories;
+        for (auto& dir : pluginDirectories)
+            directories.add(dir.getFullPathName());
+
+        obj->setProperty("pluginDirectories", juce::var(directories));
+        auto json = juce::JSON::toString(juce::var(obj.get()), true);
+        return file.replaceWithText(json);
+    }
+}

--- a/src/persist/Config.h
+++ b/src/persist/Config.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <vector>
+
+namespace host::persist
+{
+    struct EngineSettings
+    {
+        double sampleRate { 48000.0 };
+        int blockSize { 256 };
+    };
+
+    class Config
+    {
+    public:
+        Config() = default;
+
+        void setEngineSettings(const EngineSettings& settings) { engineSettings = settings; }
+        EngineSettings getEngineSettings() const noexcept { return engineSettings; }
+
+        void setPluginDirectories(const std::vector<juce::File>& dirs);
+        const std::vector<juce::File>& getPluginDirectories() const noexcept { return pluginDirectories; }
+
+        bool load(const juce::File& file);
+        bool save(const juce::File& file) const;
+
+    private:
+        EngineSettings engineSettings;
+        std::vector<juce::File> pluginDirectories;
+    };
+}

--- a/src/persist/Preset.cpp
+++ b/src/persist/Preset.cpp
@@ -1,0 +1,32 @@
+#include "persist/Preset.h"
+
+namespace host::persist
+{
+    bool Preset::load(const juce::File& file)
+    {
+        if (! file.existsAsFile())
+            return false;
+
+        juce::FileInputStream stream(file);
+        if (! stream.openedOk())
+            return false;
+
+        name = stream.readString();
+        auto remaining = static_cast<size_t>(stream.getNumBytesRemaining());
+        state.setSize(remaining);
+        stream.read(state.getData(), static_cast<int>(remaining));
+        return true;
+    }
+
+    bool Preset::save(const juce::File& file) const
+    {
+        juce::FileOutputStream stream(file);
+        if (! stream.openedOk())
+            return false;
+
+        stream.writeString(name);
+        stream.write(state.getData(), state.getSize());
+        stream.flush();
+        return true;
+    }
+}

--- a/src/persist/Preset.h
+++ b/src/persist/Preset.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace host::persist
+{
+    class Preset
+    {
+    public:
+        bool load(const juce::File& file);
+        bool save(const juce::File& file) const;
+
+        juce::String getName() const noexcept { return name; }
+        void setName(juce::String newName) { name = std::move(newName); }
+
+    private:
+        juce::String name { "Default" };
+        juce::MemoryBlock state;
+    };
+}

--- a/src/persist/Project.cpp
+++ b/src/persist/Project.cpp
@@ -1,0 +1,46 @@
+#include "persist/Project.h"
+
+namespace host::persist
+{
+    bool Project::load(const juce::File& file)
+    {
+        if (! file.existsAsFile())
+            return false;
+
+        juce::String jsonText = file.loadFileAsString();
+        juce::var root;
+        auto result = juce::JSON::parse(jsonText, root);
+        if (result.failed())
+            return false;
+
+        if (auto* object = root.getDynamicObject())
+            projectName = object->getProperty("name");
+
+        return true;
+    }
+
+    bool Project::save(const juce::File& file, const host::graph::GraphEngine& graph) const
+    {
+        juce::DynamicObject::Ptr root(new juce::DynamicObject());
+        root->setProperty("name", projectName);
+        root->setProperty("version", 1);
+
+        juce::Array<juce::var> nodes;
+        for (auto& id : graph.getSchedule())
+        {
+            if (auto* node = graph.getNode(id))
+            {
+                juce::DynamicObject::Ptr nodeObj(new juce::DynamicObject());
+                nodeObj->setProperty("id", id.toString());
+                nodeObj->setProperty("name", juce::String(node->name()));
+                nodeObj->setProperty("latency", node->latencySamples());
+                nodes.add(juce::var(nodeObj.get()));
+            }
+        }
+
+        root->setProperty("nodes", juce::var(nodes));
+
+        auto json = juce::JSON::toString(juce::var(root.get()), true);
+        return file.replaceWithText(json);
+    }
+}

--- a/src/persist/Project.h
+++ b/src/persist/Project.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "graph/GraphEngine.h"
+
+namespace host::persist
+{
+    class Project
+    {
+    public:
+        bool load(const juce::File& file);
+        bool save(const juce::File& file, const host::graph::GraphEngine& graph) const;
+
+        juce::String getProjectName() const noexcept { return projectName; }
+
+    private:
+        juce::String projectName { "Untitled" };
+    };
+}


### PR DESCRIPTION
## Summary
- set up CMake build targeting MSVC C++20 with JUCE, VST3 SDK, and optional VST2 headers
- implement audio graph engine, device resampling bridge, plugin host/scanner abstractions, and persistence stubs
- add JUCE GUI shell with main window, graph view, plugin browser, and preferences along with sample project/cache data

## Testing
- not run (JUCE and SDK dependencies not present in container)


------
https://chatgpt.com/codex/tasks/task_e_68e517ce51308330a7fa0e9b852d5dc1