### PR TITLE
Make VST2 support mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,20 @@ if(MSVC)
     add_compile_options(/permissive- /Zc:__cplusplus /EHsc /O2 /DNDEBUG)
 endif()
 
-add_definitions(-DVST3_SDK)
-
-option(ENABLE_VST2 "Enable VST2 hosting" ON)
+add_definitions(-DVST3_SDK -DENABLE_VST2)
 
 set(JUCE_SUBMODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/JUCE)
 set(VST3_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/VST3_SDK)
 set(VST2_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/externals/vst2sdk)
+
+if (NOT EXISTS "${CMAKE_SOURCE_DIR}/externals/vst2sdk/include/aeffect.h")
+    message(FATAL_ERROR "Xaymar VST2 SDK missing at externals/vst2sdk")
+endif()
+
+include_directories(
+    ${CMAKE_SOURCE_DIR}/externals/VST3_SDK
+    ${CMAKE_SOURCE_DIR}/externals/vst2sdk/include
+)
 
 if(NOT EXISTS ${JUCE_SUBMODULE_DIR}/CMakeLists.txt)
     message(FATAL_ERROR "JUCE submodule not found. Please initialise submodules under externals/JUCE.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,15 +25,11 @@ set(SOURCES
 
 add_executable(VSTHostApp ${SOURCES})
 
-if(ENABLE_VST2)
-    target_compile_definitions(VSTHostApp PRIVATE ENABLE_VST2)
-    target_include_directories(VSTHostApp PRIVATE ${VST2_SDK_DIR}/include)
-endif()
-
 target_include_directories(VSTHostApp
     PRIVATE
         ${SRC_DIR}
         ${VST3_SDK_DIR}
+        ${VST2_SDK_DIR}/include
 )
 
 target_link_libraries(VSTHostApp


### PR DESCRIPTION
## Summary
- enforce VST2 support by enabling the SDK definitions and validating the native headers
- expose VST2 and VST3 include directories globally for the build
- streamline the app target to always include the VST2 SDK headers while linking required JUCE modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e524452e908330bddc533fbc346643