### PR TITLE
Implement streaming resamplers and device engine

### DIFF
--- a/src/audio/Resampler.h
+++ b/src/audio/Resampler.h
@@ -1,63 +1,240 @@
 #pragma once
 
 #include <juce_dsp/juce_dsp.h>
-#include <memory>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
 #include <vector>
 
 namespace host::audio
 {
-    /** Simple per-channel resampler abstraction to allow swapping implementations later. */
-    class Resampler
+    /**
+        Streaming resampler for a single channel.
+
+        The resampler maintains an internal FIFO so that callers can push
+        arbitrary-sized blocks and pull blocks of a different size/sample-rate
+        without performing any allocations during the audio callback.
+    */
+    class ChannelResampler
     {
     public:
-        Resampler() = default;
+        ChannelResampler() = default;
 
-        void prepare(int numChannels, double ratio)
+        void prepare(double speedRatio, int bufferCapacity, int safetyMargin = 8)
         {
-            if (channels != numChannels)
-            {
-                resamplers.clear();
-                resamplers.reserve(static_cast<size_t>(numChannels));
-                for (int i = 0; i < numChannels; ++i)
-                    resamplers.emplace_back(std::make_unique<juce::LagrangeInterpolator>());
-                channels = numChannels;
-            }
-
-            resampleRatio = ratio;
-            for (auto& r : resamplers)
-                r->reset();
+            ratio = speedRatio > 0.0 ? speedRatio : 1.0;
+            margin = std::max(safetyMargin, 4);
+            buffer.resize(static_cast<size_t>(bufferCapacity));
+            stored = 0;
+            interpolator.reset();
         }
 
         void reset()
         {
-            for (auto& r : resamplers)
-                r->reset();
+            stored = 0;
+            interpolator.reset();
         }
 
-        void process(const float* const* input, int numInputSamples, float* const* output, int numOutputSamples)
+        void push(const float* samples, int numSamples)
         {
-            JUCE_ASSERT_MESSAGE_MANAGER_ONLY(jassert(resampleRatio > 0.0));
-            if (resamplers.empty())
+            if (numSamples <= 0)
                 return;
 
-            for (int ch = 0; ch < channels; ++ch)
+            if (samples == nullptr)
             {
-                auto* in = input[ch];
-                auto* out = output[ch];
-                if (! in || ! out)
-                    continue;
+                std::fill_n(ensureSpace(numSamples), static_cast<size_t>(numSamples), 0.0f);
+                stored += numSamples;
+                return;
+            }
 
-                auto& interpolator = *resamplers[static_cast<size_t>(ch)];
-                interpolator.process(resampleRatio, in, out, numOutputSamples);
+            auto* dest = ensureSpace(numSamples);
+            std::memcpy(dest, samples, static_cast<size_t>(numSamples) * sizeof(float));
+            stored += numSamples;
+        }
+
+        [[nodiscard]] bool canProcess(int numOutputSamples) const noexcept
+        {
+            if (numOutputSamples <= 0)
+                return false;
+
+            const double required = numOutputSamples * ratio;
+            const int needed = static_cast<int>(std::ceil(required)) + margin;
+            return stored >= needed;
+        }
+
+        int process(float* output, int numOutputSamples)
+        {
+            if (output == nullptr || numOutputSamples <= 0)
+                return 0;
+
+            if (stored <= 0)
+            {
+                std::fill_n(output, static_cast<size_t>(numOutputSamples), 0.0f);
+                return 0;
+            }
+
+            const auto available = stored;
+            const double required = numOutputSamples * ratio;
+            const int needed = static_cast<int>(std::ceil(required)) + margin;
+
+            const int maxOutputs = (ratio > 0.0)
+                ? static_cast<int>(std::floor(std::max(0.0, static_cast<double>(available - margin)) / ratio))
+                : available;
+
+            const int outputsToProduce = (available >= needed)
+                ? numOutputSamples
+                : std::clamp(maxOutputs, 0, numOutputSamples);
+
+            if (outputsToProduce <= 0)
+            {
+                std::fill_n(output, static_cast<size_t>(numOutputSamples), 0.0f);
+                return 0;
+            }
+
+            const int consumed = interpolator.process(ratio, buffer.data(), output, outputsToProduce);
+            consume(consumed);
+
+            if (outputsToProduce < numOutputSamples)
+                std::fill(output + outputsToProduce, output + numOutputSamples, 0.0f);
+
+            return outputsToProduce;
+        }
+
+        [[nodiscard]] int getStoredSamples() const noexcept { return stored; }
+
+    private:
+        float* ensureSpace(int additional)
+        {
+            const int capacity = static_cast<int>(buffer.size());
+            if (stored + additional <= capacity)
+                return buffer.data() + stored;
+
+            const int required = stored + additional;
+            if (required > capacity)
+            {
+                // If we run out of space, drop the oldest samples to make room.
+                const int excess = required - capacity;
+                if (excess >= stored)
+                {
+                    stored = 0;
+                }
+                else
+                {
+                    std::memmove(buffer.data(), buffer.data() + excess, static_cast<size_t>(stored - excess) * sizeof(float));
+                    stored -= excess;
+                }
+            }
+
+            return buffer.data() + stored;
+        }
+
+        void consume(int numSamples)
+        {
+            if (numSamples <= 0)
+                return;
+
+            stored = std::max(0, stored - numSamples);
+            if (stored > 0)
+                std::memmove(buffer.data(), buffer.data() + numSamples, static_cast<size_t>(stored) * sizeof(float));
+        }
+
+        double ratio { 1.0 };
+        int margin { 8 };
+        std::vector<float> buffer;
+        int stored { 0 };
+        juce::LagrangeInterpolator interpolator;
+    };
+
+    /** Multi-channel wrapper around ChannelResampler. */
+    class BlockResampler
+    {
+    public:
+        BlockResampler() = default;
+
+        void prepare(int numChannels,
+                     double speedRatio,
+                     int maxInputChunk,
+                     int maxOutputChunk,
+                     int safetyMargin = 8)
+        {
+            channels.resize(static_cast<size_t>(std::max(0, numChannels)));
+            ratio = speedRatio > 0.0 ? speedRatio : 1.0;
+            margin = std::max(safetyMargin, 4);
+            maxInput = std::max(maxInputChunk, 1);
+            maxOutput = std::max(maxOutputChunk, 1);
+            discardBuffer.resize(static_cast<size_t>(maxOutput));
+
+            const int capacity = computeCapacity();
+            for (auto& ch : channels)
+                ch.prepare(ratio, capacity, margin);
+        }
+
+        void reset()
+        {
+            for (auto& ch : channels)
+                ch.reset();
+        }
+
+        void push(const float* const* inputs, int numSamples)
+        {
+            if (channels.empty() || numSamples <= 0)
+                return;
+
+            for (size_t i = 0; i < channels.size(); ++i)
+            {
+                const auto* source = (inputs != nullptr) ? inputs[i] : nullptr;
+                channels[i].push(source, numSamples);
             }
         }
 
-        double getRatio() const noexcept { return resampleRatio; }
-        int getNumChannels() const noexcept { return channels; }
+        [[nodiscard]] bool canProcess(int numOutputSamples) const
+        {
+            if (channels.empty())
+                return false;
+
+            for (const auto& ch : channels)
+            {
+                if (! ch.canProcess(numOutputSamples))
+                    return false;
+            }
+            return true;
+        }
+
+        int process(float* const* outputs, int numOutputSamples)
+        {
+            if (channels.empty() || outputs == nullptr)
+                return 0;
+
+            int produced = numOutputSamples;
+            for (size_t i = 0; i < channels.size(); ++i)
+            {
+                auto* dest = outputs[i] != nullptr ? outputs[i] : discardBuffer.data();
+                const int channelProduced = channels[i].process(dest, numOutputSamples);
+                produced = std::min(produced, channelProduced);
+
+                if (outputs[i] == nullptr && channelProduced > 0)
+                    std::fill(discardBuffer.begin(), discardBuffer.begin() + channelProduced, 0.0f);
+            }
+
+            return produced;
+        }
+
+        [[nodiscard]] int getNumChannels() const noexcept { return static_cast<int>(channels.size()); }
 
     private:
-        int channels { 0 };
-        double resampleRatio { 1.0 };
-        std::vector<std::unique_ptr<juce::LagrangeInterpolator>> resamplers;
+        [[nodiscard]] int computeCapacity() const
+        {
+            const double requiredForOutput = std::ceil(maxOutput * ratio) + margin + 8.0;
+            const int base = static_cast<int>(std::max({ requiredForOutput, static_cast<double>(maxInput), static_cast<double>(maxOutput) }));
+            return std::max(base * 2, maxInput * 4);
+        }
+
+        std::vector<ChannelResampler> channels;
+        double ratio { 1.0 };
+        int margin { 8 };
+        int maxInput { 0 };
+        int maxOutput { 0 };
+        std::vector<float> discardBuffer;
     };
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -20,14 +20,16 @@ MainWindow::MainWindow()
     : juce::DocumentWindow("VST Host Scaffold", juce::Colours::darkgrey, juce::DocumentWindow::allButtons),
       graphEngine(std::make_shared<host::graph::GraphEngine>()),
       pluginScanner(std::make_shared<host::plugin::PluginScanner>()),
-      deviceEngine(graphEngine)
+      deviceEngine()
 {
     setUsingNativeTitleBar(true);
     setResizable(true, true);
 
+    deviceEngine.setGraph(graphEngine);
+    deviceEngine.setEngineConfig({ 48000.0, 256 });
+
     deviceManager.initialise(0, 2, nullptr, true);
     deviceManager.addAudioCallback(&deviceEngine);
-    deviceEngine.setConfig({ 48000.0, 256 });
 
     pluginBrowser.setScanner(pluginScanner);
     graphView.setGraph(graphEngine);

--- a/src/gui/Preferences.cpp
+++ b/src/gui/Preferences.cpp
@@ -44,9 +44,9 @@ namespace host::gui
         engineSampleRateBox.setSelectedId(2);
         engineSampleRateBox.onChange = [this]
         {
-            auto cfg = deviceEngine.getConfig();
+            auto cfg = deviceEngine.getEngineConfig();
             cfg.sampleRate = engineSampleRateBox.getText().getDoubleValue();
-            deviceEngine.setConfig(cfg);
+            deviceEngine.setEngineConfig(cfg);
         };
 
         engineBlockBox.addItem("128", 1);
@@ -55,9 +55,9 @@ namespace host::gui
         engineBlockBox.setSelectedId(2);
         engineBlockBox.onChange = [this]
         {
-            auto cfg = deviceEngine.getConfig();
+            auto cfg = deviceEngine.getEngineConfig();
             cfg.blockSize = engineBlockBox.getText().getIntValue();
-            deviceEngine.setConfig(cfg);
+            deviceEngine.setEngineConfig(cfg);
         };
 
         refreshDeviceList();


### PR DESCRIPTION
## Summary
- add ChannelResampler and BlockResampler streaming wrappers around juce::LagrangeInterpolator
- refactor DeviceEngine to manage engine/device formats, resampling, and scratch buffers without allocations in the callback
- update GUI components to configure the new DeviceEngine API

## Testing
- cmake -S . -B build *(fails: Xaymar VST2 SDK missing at externals/vst2sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68e5258a18d08330ae82aa42e212c0a2