### PR TITLE
Add VST plugin hosting support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SOURCES
     ${SRC_DIR}/graph/GraphEngine.cpp
     ${SRC_DIR}/graph/Nodes/AudioIn.h
     ${SRC_DIR}/graph/Nodes/AudioOut.h
-    ${SRC_DIR}/graph/Nodes/VstFx.h
+    ${SRC_DIR}/graph/Nodes/VstFx.cpp
     ${SRC_DIR}/graph/Nodes/Gain.h
     ${SRC_DIR}/graph/Nodes/Mix.h
     ${SRC_DIR}/graph/Nodes/Split.h

--- a/src/graph/Nodes/VstFx.cpp
+++ b/src/graph/Nodes/VstFx.cpp
@@ -1,0 +1,52 @@
+#include "graph/Nodes/VstFx.h"
+
+#include <utility>
+
+namespace host::graph::nodes
+{
+    VstFxNode::VstFxNode(std::unique_ptr<host::plugin::PluginInstance> instance, std::string pluginName)
+        : instance_(std::move(instance))
+        , pluginName_(std::move(pluginName))
+    {
+    }
+
+    void VstFxNode::prepare(double sampleRate, int blockSize)
+    {
+        preparedSampleRate_ = sampleRate;
+        preparedBlockSize_ = blockSize;
+        if (instance_)
+            instance_->prepare(sampleRate, blockSize);
+    }
+
+    void VstFxNode::process(ProcessContext& context)
+    {
+        if (! instance_ || bypassed_.load())
+            return;
+
+        auto& buffer = context.audioBuffer;
+        const auto numChannels = buffer.getNumChannels();
+        const auto numSamples = buffer.getNumSamples();
+
+        if (preparedSampleRate_ != context.sampleRate || preparedBlockSize_ != context.blockSize)
+        {
+            preparedSampleRate_ = context.sampleRate;
+            preparedBlockSize_ = context.blockSize;
+            instance_->prepare(preparedSampleRate_, preparedBlockSize_);
+        }
+
+        float** channelData = buffer.getArrayOfWritePointers();
+        instance_->process(channelData, numChannels, channelData, numChannels, numSamples);
+    }
+
+    int VstFxNode::latencySamples() const noexcept
+    {
+        return instance_ ? instance_->latencySamples() : 0;
+    }
+
+    std::string VstFxNode::name() const
+    {
+        if (! pluginName_.empty())
+            return pluginName_;
+        return "VST FX";
+    }
+}

--- a/src/host/PluginHost.cpp
+++ b/src/host/PluginHost.cpp
@@ -1,77 +1,687 @@
 #include "host/PluginHost.h"
 
-#include <utility>
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <optional>
+
+#if defined(_WIN32)
+ #include <windows.h>
+#else
+ #include <dlfcn.h>
+#endif
+
+#include <pluginterfaces/base/ibstream.h>
+#include <pluginterfaces/base/ipluginbase.h>
+#include <pluginterfaces/base/ipluginfactory.h>
+#include <pluginterfaces/base/funknown.h>
+#include <pluginterfaces/vst/ivstaudioprocessor.h>
+#include <pluginterfaces/vst/ivstcomponent.h>
+#include <pluginterfaces/vst/ivsteditcontroller.h>
+#include <pluginterfaces/vst/vsttypes.h>
+
+#include <vst.h>
 
 namespace host::plugin
 {
-    VST3PluginInstance::VST3PluginInstance(std::unique_ptr<juce::AudioPluginInstance> instance)
-        : plugin(std::move(instance))
+namespace
+{
+#if defined(_WIN32)
+    using ModuleHandle = HMODULE;
+#else
+    using ModuleHandle = void*;
+#endif
+
+    class SharedLibrary
     {
-    }
+    public:
+        SharedLibrary() = default;
+        explicit SharedLibrary(const std::filesystem::path& p) { load(p); }
+        ~SharedLibrary() { unload(); }
 
-    void VST3PluginInstance::prepare(double sampleRate, int blockSize)
+        SharedLibrary(const SharedLibrary&) = delete;
+        SharedLibrary& operator=(const SharedLibrary&) = delete;
+
+        SharedLibrary(SharedLibrary&& other) noexcept
+            : handle(other.handle)
+        {
+            other.handle = {};
+        }
+
+        SharedLibrary& operator=(SharedLibrary&& other) noexcept
+        {
+            if (this != &other)
+            {
+                unload();
+                handle = other.handle;
+                other.handle = {};
+            }
+            return *this;
+        }
+
+        bool load(const std::filesystem::path& p)
+        {
+            unload();
+#if defined(_WIN32)
+            handle = ::LoadLibraryW(p.wstring().c_str());
+#else
+            handle = ::dlopen(p.string().c_str(), RTLD_NOW);
+#endif
+            return handle != nullptr;
+        }
+
+        void unload()
+        {
+            if (! handle)
+                return;
+#if defined(_WIN32)
+            ::FreeLibrary(handle);
+#else
+            ::dlclose(handle);
+#endif
+            handle = {};
+        }
+
+        [[nodiscard]] void* getSymbol(const char* name) const
+        {
+            if (! handle)
+                return nullptr;
+#if defined(_WIN32)
+            return reinterpret_cast<void*>(::GetProcAddress(handle, name));
+#else
+            return ::dlsym(handle, name);
+#endif
+        }
+
+        [[nodiscard]] bool isLoaded() const noexcept { return handle != nullptr; }
+
+    private:
+        ModuleHandle handle {};
+    };
+
+    class MemoryStream final : public Steinberg::IBStream
     {
-        if (plugin)
-            plugin->prepareToPlay(sampleRate, blockSize);
-    }
+    public:
+        explicit MemoryStream(std::vector<std::uint8_t>& target)
+            : writeBuffer(&target)
+        {
+        }
 
-    void VST3PluginInstance::process(juce::AudioBuffer<float>& buffer)
+        MemoryStream(const std::uint8_t* data, std::size_t sizeIn)
+            : readBuffer(data)
+            , readSize(sizeIn)
+        {
+        }
+
+        // FUnknown
+        Steinberg::uint32 PLUGIN_API addRef() override { return ++refCount; }
+
+        Steinberg::uint32 PLUGIN_API release() override
+        {
+            auto newCount = --refCount;
+            if (newCount == 0)
+                delete this;
+            return newCount;
+        }
+
+        tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+        {
+            if (std::memcmp(iid, Steinberg::IBStream::iid, sizeof(Steinberg::TUID)) == 0)
+            {
+                addRef();
+                *obj = static_cast<Steinberg::IBStream*>(this);
+                return Steinberg::kResultOk;
+            }
+
+            *obj = nullptr;
+            return Steinberg::kNoInterface;
+        }
+
+        // IBStream
+        Steinberg::tresult PLUGIN_API read(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesRead) override
+        {
+            if (! readBuffer)
+            {
+                if (numBytesRead)
+                    *numBytesRead = 0;
+                return Steinberg::kResultFalse;
+            }
+
+            const auto bytesAvailable = static_cast<Steinberg::int64>(readSize) - position;
+            const auto toRead = static_cast<Steinberg::int32>(std::max<Steinberg::int64>(0, std::min<Steinberg::int64>(bytesAvailable, numBytes)));
+            if (toRead > 0)
+                std::memcpy(buffer, readBuffer + position, static_cast<std::size_t>(toRead));
+
+            position += toRead;
+            if (numBytesRead)
+                *numBytesRead = toRead;
+            return toRead == numBytes ? Steinberg::kResultOk : Steinberg::kResultTrue;
+        }
+
+        Steinberg::tresult PLUGIN_API write(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesWritten) override
+        {
+            if (! writeBuffer)
+            {
+                if (numBytesWritten)
+                    *numBytesWritten = 0;
+                return Steinberg::kResultFalse;
+            }
+
+            auto* src = static_cast<std::uint8_t*>(buffer);
+            if (position + numBytes > static_cast<Steinberg::int64>(writeBuffer->size()))
+                writeBuffer->resize(static_cast<std::size_t>(position + numBytes));
+
+            std::memcpy(writeBuffer->data() + position, src, static_cast<std::size_t>(numBytes));
+            position += numBytes;
+            if (numBytesWritten)
+                *numBytesWritten = numBytes;
+            return Steinberg::kResultOk;
+        }
+
+        Steinberg::tresult PLUGIN_API seek(Steinberg::int64 pos, Steinberg::int32 mode, Steinberg::int64* result) override
+        {
+            Steinberg::int64 newPos = position;
+            switch (mode)
+            {
+            case Steinberg::IBStream::kIBSeekSet: newPos = pos; break;
+            case Steinberg::IBStream::kIBSeekCur: newPos += pos; break;
+            case Steinberg::IBStream::kIBSeekEnd:
+                if (writeBuffer)
+                    newPos = static_cast<Steinberg::int64>(writeBuffer->size()) + pos;
+                else
+                    newPos = static_cast<Steinberg::int64>(readSize) + pos;
+                break;
+            default: return Steinberg::kResultFalse;
+            }
+
+            if (newPos < 0)
+                newPos = 0;
+
+            if (writeBuffer && newPos > static_cast<Steinberg::int64>(writeBuffer->size()))
+                writeBuffer->resize(static_cast<std::size_t>(newPos));
+
+            position = newPos;
+            if (result)
+                *result = position;
+            return Steinberg::kResultOk;
+        }
+
+        Steinberg::tresult PLUGIN_API tell(Steinberg::int64* pos) override
+        {
+            if (! pos)
+                return Steinberg::kInvalidArgument;
+            *pos = position;
+            return Steinberg::kResultOk;
+        }
+
+    private:
+        std::atomic<Steinberg::uint32> refCount { 1 };
+        std::vector<std::uint8_t>* writeBuffer { nullptr };
+        const std::uint8_t* readBuffer { nullptr };
+        std::size_t readSize { 0 };
+        Steinberg::int64 position { 0 };
+    };
+
+    class Vst3PluginInstance final : public PluginInstance
     {
-        if (! plugin)
-            return;
+    public:
+        Vst3PluginInstance(SharedLibrary&& moduleIn,
+                           Steinberg::Vst::IComponent* componentIn,
+                           Steinberg::Vst::IAudioProcessor* processorIn,
+                           Steinberg::Vst::IEditController* controllerIn,
+                           int inChannels,
+                           int outChannels,
+                           bool alreadyInitialized)
+            : module(std::move(moduleIn))
+            , component(componentIn)
+            , processor(processorIn)
+            , controller(controllerIn)
+            , maxInputs(inChannels)
+            , maxOutputs(outChannels)
+            , initialized(alreadyInitialized)
+        {
+        }
 
-        juce::MidiBuffer midi;
-        plugin->processBlock(buffer, midi);
-    }
+        ~Vst3PluginInstance() override { shutdown(); }
 
-    int VST3PluginInstance::getLatencySamples() const noexcept
+        void prepare(double sr, int block) override
+        {
+            if (! component || ! processor)
+                return;
+
+            ensureInitialized();
+
+            if (processing)
+            {
+                processor->setProcessing(false);
+                processing = false;
+            }
+
+            if (active)
+            {
+                component->setActive(false);
+                active = false;
+            }
+
+            Steinberg::Vst::SpeakerArrangement inArr = Steinberg::Vst::SpeakerArr::kStereo;
+            Steinberg::Vst::SpeakerArrangement outArr = Steinberg::Vst::SpeakerArr::kStereo;
+            if (processor->setBusArrangements(&inArr, 1, &outArr, 1) != Steinberg::kResultOk)
+                return;
+
+            setup.processMode = Steinberg::Vst::kRealtime;
+            setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+            setup.maxSamplesPerBlock = block;
+            setup.sampleRate = sr;
+            if (processor->setupProcessing(setup) != Steinberg::kResultOk)
+                return;
+
+            component->setActive(true);
+            active = true;
+
+            processor->setProcessing(true);
+            processing = true;
+
+            latency = std::max(component->getLatencySamples(), processor->getLatencySamples());
+        }
+
+        void process(float** in, int inCh, float** out, int outCh, int numFrames) override
+        {
+            if (! processor || ! processing || ! in || ! out)
+                return;
+
+            const auto usedInputs = std::min(inCh, maxInputs);
+            const auto usedOutputs = std::min(outCh, maxOutputs);
+
+            Steinberg::Vst::AudioBusBuffers inputs[1] {};
+            Steinberg::Vst::AudioBusBuffers outputs[1] {};
+
+            inputs[0].numChannels = usedInputs;
+            inputs[0].silenceFlags = 0;
+            inputs[0].channelBuffers32 = in;
+
+            outputs[0].numChannels = usedOutputs;
+            outputs[0].silenceFlags = 0;
+            outputs[0].channelBuffers32 = out;
+
+            Steinberg::Vst::ProcessData data {};
+            data.numInputs = 1;
+            data.numOutputs = 1;
+            data.numSamples = numFrames;
+            data.symbolicSampleSize = Steinberg::Vst::kSample32;
+            data.inputs = inputs;
+            data.outputs = outputs;
+
+            processor->process(data);
+            latency = std::max(latency, processor->getLatencySamples());
+        }
+
+        [[nodiscard]] int latencySamples() const override { return latency; }
+
+        bool getState(std::vector<std::uint8_t>& outState) override
+        {
+            if (! component)
+                return false;
+
+            outState.clear();
+            auto* stream = new MemoryStream(outState);
+            const auto result = component->getState(stream);
+            stream->release();
+            if (result == Steinberg::kResultOk)
+                return true;
+
+            if (controller)
+            {
+                outState.clear();
+                stream = new MemoryStream(outState);
+                const auto ctrlResult = controller->getState(stream);
+                stream->release();
+                return ctrlResult == Steinberg::kResultOk;
+            }
+
+            return false;
+        }
+
+        bool setState(const std::uint8_t* data, std::size_t len) override
+        {
+            if (! component || ! data || len == 0)
+                return false;
+
+            auto* stream = new MemoryStream(data, len);
+            const auto result = component->setState(stream);
+            stream->release();
+            if (result == Steinberg::kResultOk)
+                return true;
+
+            if (controller)
+            {
+                stream = new MemoryStream(data, len);
+                const auto ctrlResult = controller->setState(stream);
+                stream->release();
+                return ctrlResult == Steinberg::kResultOk;
+            }
+
+            return false;
+        }
+
+    private:
+        void ensureInitialized()
+        {
+            if (initialized || ! component)
+                return;
+
+            if (component->initialize(nullptr) == Steinberg::kResultOk)
+            {
+                component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kInput, 0, true);
+                component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput, 0, true);
+                initialized = true;
+            }
+        }
+
+        void shutdown()
+        {
+            if (processor && processing)
+            {
+                processor->setProcessing(false);
+                processing = false;
+            }
+
+            if (component && active)
+            {
+                component->setActive(false);
+                active = false;
+            }
+
+            if (controller)
+            {
+                controller->setComponentHandler(nullptr);
+                controller->release();
+                controller = nullptr;
+            }
+
+            if (component)
+            {
+                if (initialized)
+                    component->terminate();
+                component->release();
+                component = nullptr;
+            }
+
+            if (processor)
+            {
+                processor->release();
+                processor = nullptr;
+            }
+        }
+
+        SharedLibrary module;
+        Steinberg::Vst::IComponent* component { nullptr };
+        Steinberg::Vst::IAudioProcessor* processor { nullptr };
+        Steinberg::Vst::IEditController* controller { nullptr };
+        Steinberg::Vst::ProcessSetup setup {};
+        bool initialized { false };
+        bool active { false };
+        bool processing { false };
+        int latency { 0 };
+        int maxInputs { 0 };
+        int maxOutputs { 0 };
+    };
+
+    constexpr int kVst2MaxChannels = 32;
+
+    class Vst2PluginInstance final : public PluginInstance
     {
-        return plugin ? plugin->getLatencySamples() : 0;
-    }
+    public:
+        Vst2PluginInstance(SharedLibrary&& moduleIn, vst_effect_t* effectIn)
+            : module(std::move(moduleIn))
+            , effect(effectIn)
+        {
+        }
 
-    std::string VST3PluginInstance::getName() const
+        ~Vst2PluginInstance() override { shutdown(); }
+
+        void prepare(double sr, int block) override
+        {
+            if (! effect)
+                return;
+
+            sampleRate = sr;
+            blockSize = block;
+
+            effect->control(effect, VST_EFFECT_OPCODE_SET_SAMPLE_RATE, 0, 0, nullptr, static_cast<float>(sr));
+            effect->control(effect, VST_EFFECT_OPCODE_SET_BLOCK_SIZE, 0, block, nullptr, 0.0f);
+            effect->control(effect, VST_EFFECT_OPCODE_SUSPEND_RESUME, 0, 1, nullptr, 0.0f);
+            active = true;
+            replacing = (effect->flags & VST_EFFECT_FLAG_SUPPORTS_FLOAT) != 0 && effect->process_float != nullptr;
+
+            scratch.resize(static_cast<std::size_t>(std::max(1, effect->num_outputs) * block));
+            latency = effect->delay;
+        }
+
+        void process(float** in, int inCh, float** out, int outCh, int numFrames) override
+        {
+            if (! effect || ! active || ! in || ! out)
+                return;
+
+            if (numFrames > blockSize)
+                return;
+
+            if (effect->num_inputs != inCh || effect->num_outputs != outCh)
+                return;
+
+            std::array<const float*, kVst2MaxChannels> inputs {};
+            std::array<float*, kVst2MaxChannels> outputs {};
+
+            for (int c = 0; c < outCh; ++c)
+            {
+                inputs[c] = (c < inCh && in[c]) ? in[c] : nullptr;
+                outputs[c] = out[c];
+            }
+
+            if (replacing && effect->process_float)
+            {
+                effect->process_float(effect, inputs.data(), out, numFrames);
+            }
+            else if (effect->process)
+            {
+                for (int c = 0; c < outCh; ++c)
+                    outputs[c] = scratch.data() + static_cast<std::size_t>(c * blockSize);
+
+                effect->process(effect, inputs.data(), outputs.data(), numFrames);
+
+                for (int c = 0; c < outCh; ++c)
+                    std::copy(outputs[c], outputs[c] + numFrames, out[c]);
+            }
+
+            latency = effect->delay;
+        }
+
+        [[nodiscard]] int latencySamples() const override { return latency; }
+
+        bool getState(std::vector<std::uint8_t>& outState) override
+        {
+            if (! effect)
+                return false;
+
+            void* chunkPtr = nullptr;
+            const auto size = effect->control(effect, VST_EFFECT_OPCODE_GET_CHUNK_DATA, 0, 0, &chunkPtr, 0.0f);
+            if (size <= 0 || chunkPtr == nullptr)
+                return false;
+
+            outState.resize(static_cast<std::size_t>(size));
+            std::memcpy(outState.data(), chunkPtr, outState.size());
+            return true;
+        }
+
+        bool setState(const std::uint8_t* data, std::size_t len) override
+        {
+            if (! effect || ! data || len == 0)
+                return false;
+
+            const auto result = effect->control(effect, VST_EFFECT_OPCODE_SET_CHUNK_DATA, 0, static_cast<intptr_t>(len), const_cast<std::uint8_t*>(data), 0.0f);
+            return result == 1;
+        }
+
+    private:
+        void shutdown()
+        {
+            if (! effect)
+                return;
+
+            if (active)
+            {
+                effect->control(effect, VST_EFFECT_OPCODE_SUSPEND_RESUME, 0, 0, nullptr, 0.0f);
+                active = false;
+            }
+
+            effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, nullptr, 0.0f);
+            effect = nullptr;
+        }
+
+        SharedLibrary module;
+        vst_effect_t* effect { nullptr };
+        double sampleRate { 0.0 };
+        int blockSize { 0 };
+        bool active { false };
+        bool replacing { false };
+        int latency { 0 };
+        std::vector<float> scratch;
+    };
+
+    constexpr int32_t kVstMagic = VST_FOURCC('V', 's', 't', 'P');
+
+    intptr_t VST_FUNCTION_INTERFACE hostCallback(vst_effect_t*, int32_t opcode, int32_t, intptr_t, void*, float)
     {
-        return plugin ? plugin->getName().toStdString() : std::string{};
-    }
-
-    juce::MemoryBlock VST3PluginInstance::getState() const
-    {
-        juce::MemoryBlock block;
-        if (plugin)
-            plugin->getStateInformation(block);
-        return block;
-    }
-
-    void VST3PluginInstance::setState(const void* data, size_t size)
-    {
-        if (plugin)
-            plugin->setStateInformation(data, static_cast<int>(size));
-    }
-
-    std::shared_ptr<PluginInstance> loadPlugin(const PluginInfo& info, juce::AudioPluginFormatManager& formatManager, juce::String& error)
-    {
-        error.clear();
-
-        juce::PluginDescription desc;
-        desc.fileOrIdentifier = info.path;
-        desc.name = info.name;
-        desc.pluginFormatName = info.format == PluginFormat::VST3 ? "VST3" : "VST";
-
-        std::unique_ptr<juce::AudioPluginInstance> instance(formatManager.createPluginInstance(desc, 48000.0, 512, error));
-        if (! instance)
-            return nullptr;
-
-        if (info.format == PluginFormat::VST3)
-            return std::make_shared<VST3PluginInstance>(std::move(instance));
-
-    #if ENABLE_VST2
-        // TODO: wrap VST2 instance into a PluginInstance implementation.
-        juce::ignoreUnused(error);
-        return std::make_shared<VST3PluginInstance>(std::move(instance));
-    #else
-        juce::ignoreUnused(instance);
-        error = "VST2 support disabled";
-        return nullptr;
-    #endif
+        if (opcode == VST_HOST_OPCODE_VST_VERSION)
+            return VST_VERSION_2_4_0_0;
+        return 0;
     }
 }
+
+std::unique_ptr<PluginInstance> loadVst3(const PluginInfo& info)
+{
+    SharedLibrary module;
+    if (! module.load(info.path))
+        return nullptr;
+
+    using GetFactoryProc = Steinberg::IPluginFactory*(*)();
+    auto* symbol = module.getSymbol("GetPluginFactory");
+    if (! symbol)
+        return nullptr;
+
+    auto factory = reinterpret_cast<GetFactoryProc>(symbol)();
+    if (! factory)
+        return nullptr;
+
+    Steinberg::FUID requestedClassId;
+    const bool hasRequestedId = ! info.id.empty() && requestedClassId.fromString(info.id.c_str());
+
+    Steinberg::PClassInfo2 classInfo {};
+    Steinberg::Vst::IComponent* component = nullptr;
+    Steinberg::Vst::IAudioProcessor* processor = nullptr;
+    Steinberg::Vst::IEditController* controller = nullptr;
+
+    const auto count = factory->countClasses();
+    for (Steinberg::int32 i = 0; i < count; ++i)
+    {
+        if (factory->getClassInfo2(i, &classInfo) != Steinberg::kResultOk)
+            continue;
+
+        if (std::strcmp(classInfo.category, Steinberg::Vst::kVstAudioEffectClass) != 0)
+            continue;
+
+        Steinberg::FUID currentId(classInfo.cid);
+        if (hasRequestedId && !(currentId == requestedClassId))
+            continue;
+
+        if (factory->createInstance(classInfo.cid, Steinberg::Vst::IComponent::iid, reinterpret_cast<void**>(&component)) != Steinberg::kResultOk || ! component)
+            continue;
+
+        if (component->queryInterface(Steinberg::Vst::IAudioProcessor::iid, reinterpret_cast<void**>(&processor)) != Steinberg::kResultOk || ! processor)
+        {
+            component->release();
+            component = nullptr;
+            continue;
+        }
+
+        if (factory->createInstance(classInfo.cid, Steinberg::Vst::IEditController::iid, reinterpret_cast<void**>(&controller)) == Steinberg::kResultOk && controller)
+        {
+            if (controller->initialize(nullptr) != Steinberg::kResultOk)
+            {
+                controller->release();
+                controller = nullptr;
+            }
+        }
+        break;
+    }
+
+    factory->release();
+
+    if (! component || ! processor)
+        return nullptr;
+
+    if (component->initialize(nullptr) != Steinberg::kResultOk)
+    {
+        processor->release();
+        component->release();
+        if (controller)
+            controller->release();
+        return nullptr;
+    }
+
+    Steinberg::Vst::BusInfo inBus {};
+    Steinberg::Vst::BusInfo outBus {};
+    if (component->getBusCount(Steinberg::Vst::kAudio, Steinberg::Vst::kInput) <= 0 || component->getBusCount(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput) <= 0 ||
+        component->getBusInfo(Steinberg::Vst::kAudio, Steinberg::Vst::kInput, 0, inBus) != Steinberg::kResultOk ||
+        component->getBusInfo(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput, 0, outBus) != Steinberg::kResultOk ||
+        inBus.channelCount != info.ins || outBus.channelCount != info.outs)
+    {
+        component->terminate();
+        processor->release();
+        component->release();
+        if (controller)
+            controller->release();
+        return nullptr;
+    }
+
+    component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kInput, 0, true);
+    component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput, 0, true);
+
+    return std::make_unique<Vst3PluginInstance>(std::move(module), component, processor, controller, info.ins, info.outs, true);
+}
+
+std::unique_ptr<PluginInstance> loadVst2(const PluginInfo& info)
+{
+    SharedLibrary module;
+    if (! module.load(info.path))
+        return nullptr;
+
+    using EntryProc = vst_effect_t* (VST_FUNCTION_INTERFACE*)(vst_host_callback_t);
+    EntryProc entry = nullptr;
+
+    if (auto* sym = module.getSymbol("VSTPluginMain"))
+        entry = reinterpret_cast<EntryProc>(sym);
+    else if (auto* sym = module.getSymbol("main"))
+        entry = reinterpret_cast<EntryProc>(sym);
+    else if (auto* sym = module.getSymbol("main_macho"))
+        entry = reinterpret_cast<EntryProc>(sym);
+
+    if (! entry)
+        return nullptr;
+
+    auto* effect = entry(&hostCallback);
+    if (! effect || effect->magic_number != kVstMagic)
+        return nullptr;
+
+    effect->control(effect, VST_EFFECT_OPCODE_CREATE, 0, 0, nullptr, 0.0f);
+
+    if (effect->num_inputs != info.ins || effect->num_outputs != info.outs)
+    {
+        effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, nullptr, 0.0f);
+        return nullptr;
+    }
+
+    return std::make_unique<Vst2PluginInstance>(std::move(module), effect);
+}
+
+} // namespace host::plugin

--- a/src/host/PluginHost.h
+++ b/src/host/PluginHost.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <juce_audio_processors/juce_audio_processors.h>
+#include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -15,43 +16,26 @@ namespace host::plugin
 
     struct PluginInfo
     {
-        std::string identifier;
+        std::string id;
         std::string name;
-        PluginFormat format;
-        std::string path;
-        std::vector<std::string> categories;
-        int numInputs { 0 };
-        int numOutputs { 0 };
-        int latency { 0 };
+        PluginFormat format { PluginFormat::VST3 };
+        std::filesystem::path path;
+        int ins = 2;
+        int outs = 2;
+        int latency = 0;
     };
 
     class PluginInstance
     {
     public:
         virtual ~PluginInstance() = default;
-        virtual void prepare(double sampleRate, int blockSize) = 0;
-        virtual void process(juce::AudioBuffer<float>& buffer) = 0;
-        virtual int getLatencySamples() const noexcept = 0;
-        virtual std::string getName() const = 0;
-        virtual juce::MemoryBlock getState() const = 0;
-        virtual void setState(const void* data, size_t size) = 0;
+        virtual void prepare(double sr, int block) = 0;
+        virtual void process(float** in, int inCh, float** out, int outCh, int numFrames) = 0;
+        [[nodiscard]] virtual int latencySamples() const = 0;
+        virtual bool getState(std::vector<std::uint8_t>& out) = 0;
+        virtual bool setState(const std::uint8_t* data, std::size_t len) = 0;
     };
 
-    class VST3PluginInstance : public PluginInstance
-    {
-    public:
-        explicit VST3PluginInstance(std::unique_ptr<juce::AudioPluginInstance> instance);
-
-        void prepare(double sampleRate, int blockSize) override;
-        void process(juce::AudioBuffer<float>& buffer) override;
-        int getLatencySamples() const noexcept override;
-        std::string getName() const override;
-        juce::MemoryBlock getState() const override;
-        void setState(const void* data, size_t size) override;
-
-    private:
-        std::unique_ptr<juce::AudioPluginInstance> plugin;
-    };
-
-    std::shared_ptr<PluginInstance> loadPlugin(const PluginInfo& info, juce::AudioPluginFormatManager& formatManager, juce::String& error);
+    std::unique_ptr<PluginInstance> loadVst3(const PluginInfo& info);
+    std::unique_ptr<PluginInstance> loadVst2(const PluginInfo& info);
 }


### PR DESCRIPTION
## Summary
- implement a unified plugin hosting API with concrete loaders for VST3 and Xaymar-based VST2 plug-ins
- add a VstFx graph node that wraps PluginInstance objects with bypass handling and latency reporting
- update the build to compile the new node implementation file

## Testing
- cmake -S . -B build *(fails: missing system packages such as Xrandr/ALSA/GL in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e53136bb3c833080fdb23974c0a2de