### PR TITLE
Implement minimal graph engine

### DIFF
--- a/src/graph/GraphEngine.h
+++ b/src/graph/GraphEngine.h
@@ -1,74 +1,44 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_core/juce_core.h>
+#include "graph/Node.h"
+
+#include <array>
 #include <memory>
+#include <utility>
 #include <vector>
-#include <map>
-#include <string>
 
 namespace host::graph
 {
-    struct ProcessContext
+class GraphEngine
+{
+public:
+    void setGraph(std::vector<std::unique_ptr<Node>> nodes,
+                  std::vector<std::pair<int, int>> edges);
+
+    void prepare(double sampleRate, int blockSize);
+    void process(float** in, int inCh, int inFrames,
+                 float** out, int outCh, int& outFrames,
+                 double sampleRate, int blockSize);
+
+private:
+    std::vector<std::unique_ptr<Node>> nodes_;
+    std::vector<std::pair<int, int>> edges_;
+    std::vector<Node*> schedule_;
+
+    struct EdgeDelay
     {
-        juce::AudioBuffer<float>& audioBuffer;
-        double sampleRate {};
-        int blockSize {};
+        int samples = 0;
+        std::vector<float> bufL;
+        std::vector<float> bufR;
+        size_t wp = 0;
     };
 
-    class Node
-    {
-    public:
-        virtual ~Node() = default;
-        virtual void prepare(double sampleRate, int blockSize) = 0;
-        virtual void process(ProcessContext& context) = 0;
-        virtual int latencySamples() const noexcept { return 0; }
-        virtual std::string name() const = 0;
-    };
+    std::vector<EdgeDelay> delays_;
 
-    using NodeId = juce::Uuid;
+    std::array<std::vector<float>, 2> scratch_;
 
-    struct Connection
-    {
-        NodeId source;
-        NodeId destination;
-    };
-
-    class GraphEngine
-    {
-    public:
-        GraphEngine();
-        ~GraphEngine();
-
-        void setEngineFormat(double sampleRate, int blockSize);
-
-        NodeId addNode(std::unique_ptr<Node> node);
-        void removeNode(NodeId id);
-        void clear();
-
-        bool connect(NodeId source, NodeId dest);
-        void disconnect(NodeId source, NodeId dest);
-
-        void setIO(NodeId input, NodeId output);
-
-        void prepare();
-        void process(juce::AudioBuffer<float>& buffer);
-
-        [[nodiscard]] Node* getNode(NodeId id) const;
-        [[nodiscard]] std::vector<NodeId> getSchedule() const { return schedule; }
-
-    private:
-        void rebuildSchedule();
-        bool detectCycle(NodeId node, std::vector<NodeId>& stack, std::vector<NodeId>& visited) const;
-        void updateLatencyAlignment();
-
-        double currentSampleRate { 48000.0 };
-        int currentBlockSize { 256 };
-        std::map<NodeId, std::unique_ptr<Node>> nodes;
-        std::vector<Connection> connections;
-        std::vector<NodeId> schedule;
-        NodeId audioInputId;
-        NodeId audioOutputId;
-        bool needsScheduleRebuild { true };
-    };
-}
+    double sampleRate_ = 0.0;
+    int blockSize_ = 0;
+    bool prepared_ = false;
+};
+} // namespace host::graph

--- a/src/graph/Node.h
+++ b/src/graph/Node.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+
+namespace host::graph
+{
+struct ProcessCtx
+{
+    float** in = nullptr;
+    int inCh = 0;
+    float** out = nullptr;
+    int outCh = 0;
+    int numFrames = 0;
+    double sampleRate = 0.0;
+    int blockSize = 0;
+};
+
+class Node
+{
+public:
+    virtual ~Node() = default;
+
+    virtual void prepare(double sampleRate, int blockSize) = 0;
+    virtual void process(ProcessCtx& ctx) = 0;
+    virtual int latencySamples() const { return 0; }
+};
+} // namespace host::graph

--- a/src/graph/Nodes/GainNode.cpp
+++ b/src/graph/Nodes/GainNode.cpp
@@ -1,0 +1,28 @@
+#include "graph/Nodes/GainNode.h"
+
+#include <algorithm>
+
+namespace host::graph::nodes
+{
+void GainNode::prepare(double sampleRate, int blockSize)
+{
+    (void) sampleRate;
+    (void) blockSize;
+}
+
+void GainNode::process(ProcessCtx& ctx)
+{
+    const float gain = gain_.load();
+    const int frames = std::max(0, ctx.numFrames);
+
+    for (int ch = 0; ch < ctx.outCh; ++ch)
+    {
+        float* channel = (ctx.out != nullptr) ? ctx.out[ch] : nullptr;
+        if (channel == nullptr)
+            continue;
+
+        for (int i = 0; i < frames; ++i)
+            channel[i] *= gain;
+    }
+}
+} // namespace host::graph::nodes

--- a/src/graph/Nodes/GainNode.h
+++ b/src/graph/Nodes/GainNode.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "graph/Node.h"
+
+#include <atomic>
+
+namespace host::graph::nodes
+{
+class GainNode : public Node
+{
+public:
+    void setGain(float newGain) noexcept { gain_.store(newGain); }
+
+    void prepare(double sampleRate, int blockSize) override;
+    void process(ProcessCtx& ctx) override;
+
+private:
+    std::atomic<float> gain_ { 1.0f };
+};
+} // namespace host::graph::nodes


### PR DESCRIPTION
## Summary
- add a lightweight ProcessCtx/Node contract for RT-safe graph nodes
- implement a single-threaded GraphEngine with precomputed schedule, scratch buffers, and delay hooks
- provide a basic GainNode that applies an in-place gain across output channels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54b47808083308e9f54c7620f7484