### PR TITLE
Implement unified VST plugin host and graph node

### DIFF
--- a/src/graph/Nodes/VstFx.cpp
+++ b/src/graph/Nodes/VstFx.cpp
@@ -18,25 +18,19 @@ namespace host::graph::nodes
             instance_->prepare(sampleRate, blockSize);
     }
 
-    void VstFxNode::process(ProcessContext& context)
+    void VstFxNode::process(ProcessCtx& ctx)
     {
         if (! instance_ || bypassed_.load())
             return;
 
-        auto& buffer = context.audioBuffer;
-        const auto numChannels = buffer.getNumChannels();
-        const auto numSamples = buffer.getNumSamples();
-
-        if (preparedSampleRate_ != context.sampleRate || preparedBlockSize_ != context.blockSize)
+        if (preparedSampleRate_ != ctx.sampleRate || preparedBlockSize_ != ctx.blockSize)
         {
-            preparedSampleRate_ = context.sampleRate;
-            preparedBlockSize_ = context.blockSize;
+            preparedSampleRate_ = ctx.sampleRate;
+            preparedBlockSize_ = ctx.blockSize;
             instance_->prepare(preparedSampleRate_, preparedBlockSize_);
         }
 
-        auto* const* inputData = buffer.getArrayOfReadPointers();
-        auto* const* outputData = buffer.getArrayOfWritePointers();
-        instance_->process(inputData, numChannels, outputData, numChannels, numSamples);
+        instance_->process(ctx.in, ctx.inCh, ctx.out, ctx.outCh, ctx.numFrames);
     }
 
     int VstFxNode::latencySamples() const noexcept
@@ -50,4 +44,4 @@ namespace host::graph::nodes
             return pluginName_;
         return "VST FX";
     }
-}
+} // namespace host::graph::nodes

--- a/src/graph/Nodes/VstFx.h
+++ b/src/graph/Nodes/VstFx.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "graph/GraphEngine.h"
+#include "graph/Node.h"
 #include "host/PluginHost.h"
 
 #include <atomic>
@@ -19,7 +19,7 @@ namespace host::graph::nodes
         [[nodiscard]] bool isBypassed() const noexcept { return bypassed_.load(); }
 
         void prepare(double sampleRate, int blockSize) override;
-        void process(ProcessContext& context) override;
+        void process(ProcessCtx& ctx) override;
         int latencySamples() const noexcept override;
         std::string name() const override;
 

--- a/src/host/PluginHost.h
+++ b/src/host/PluginHost.h
@@ -22,8 +22,7 @@ namespace host::plugin
         std::filesystem::path path;
         int ins = 2;
         int outs = 2;
-        int latency = 0;
-        std::string category;
+        int latency = 0; // samples
     };
 
     class PluginInstance
@@ -31,7 +30,7 @@ namespace host::plugin
     public:
         virtual ~PluginInstance() = default;
         virtual void prepare(double sr, int block) = 0;
-        virtual void process(const float* const* in, int inCh, float* const* out, int outCh, int numFrames) = 0;
+        virtual void process(float** in, int inCh, float** out, int outCh, int numFrames) = 0;
         [[nodiscard]] virtual int latencySamples() const = 0;
         virtual bool getState(std::vector<std::uint8_t>& out) = 0;
         virtual bool setState(const std::uint8_t* data, std::size_t len) = 0;
@@ -39,4 +38,4 @@ namespace host::plugin
 
     std::unique_ptr<PluginInstance> loadVst3(const PluginInfo& info);
     std::unique_ptr<PluginInstance> loadVst2(const PluginInfo& info);
-}
+} // namespace host::plugin

--- a/src/host/PluginScanner.cpp
+++ b/src/host/PluginScanner.cpp
@@ -92,9 +92,6 @@ namespace host::plugin
                         if (auto outs = obj->getProperty("outs"); ! outs.isVoid())
                             info.outs = static_cast<int>(outs);
                         info.latency = static_cast<int>(obj->getProperty("latency"));
-                        auto category = obj->getProperty("category").toString();
-                        if (category.isNotEmpty())
-                            info.category = category.toStdString();
                     }
                     loaded.push_back(info);
                 }
@@ -132,7 +129,6 @@ namespace host::plugin
             obj->setProperty("ins", info.ins);
             obj->setProperty("outs", info.outs);
             obj->setProperty("latency", info.latency);
-            obj->setProperty("category", info.category.empty() ? juce::String() : juce::String(info.category));
             obj->setProperty("blacklisted", false);
             juce::var pluginVar(obj.get());
             pluginArray.add(pluginVar);
@@ -169,7 +165,6 @@ namespace host::plugin
                 info.format = file.hasFileExtension(".dll") ? PluginFormat::VST2 : PluginFormat::VST3;
                 info.ins = 2;
                 info.outs = 2;
-                info.category = "Effect";
                 results.push_back(std::move(info));
             }
         }


### PR DESCRIPTION
## Summary
- add a unified plugin host interface for VST3 and Xaymar VST2 plug-ins
- wrap VST processing inside a reusable VstFx graph node with bypass support
- keep the plugin scanner cache format in sync with the streamlined PluginInfo

## Testing
- cmake -S . -B build *(fails: missing X11/Xrandr development headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e54d6292dc8330b6fe9e90baaaa1ef